### PR TITLE
fix: Handle GUI patching xapk / apks, add distinct patch-source channel colors, improve patch loading errors

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -620,7 +620,7 @@ internal object PatchCommand : Callable<Int> {
 
             // We need to check for apkm (like reddit), xapk and apks formats here
 
-            val inputApk = if (apk.extension.lowercase() in  setOf("apkm", "xapk", "apks")) {
+            val inputApk = if (app.morphe.engine.util.BundleFormats.isBundle(apk)) {
 
                 logger.info("Merging split APK bundle")
 

--- a/src/main/kotlin/app/morphe/engine/PatchEngine.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchEngine.kt
@@ -8,6 +8,7 @@
 
 package app.morphe.engine
 
+import app.morphe.engine.util.BundleFormats
 import app.morphe.engine.util.signWithLegacyFallback
 import app.morphe.patcher.Patcher
 import app.morphe.patcher.PatcherConfig
@@ -100,9 +101,11 @@ object PatchEngine {
         val failedPatches = mutableListOf<FailedPatch>()
 
         try {
-            // 1. Handle APKM format (split APK bundle)
-            val actualInputApk = if (config.inputApk.extension.equals("apkm", ignoreCase = true)) {
-                onProgress("Converting APKM to APK...")
+            // 1. Handle split-APK bundles (.apkm/.xapk/.apks) — merge splits into
+            // a single APK. ApkMerger is format-agnostic (it just extracts the
+            // .apk entries from the zip), so all three formats go through here.
+            val actualInputApk = if (BundleFormats.isBundle(config.inputApk)) {
+                onProgress("Merging split APKs...")
                 val mergedApk = File(tempDir, "${config.inputApk.nameWithoutExtension}-merged.apk")
                 ApkMerger(logger.toMorpheLogger()).merge(
                     inputFile = config.inputApk,

--- a/src/main/kotlin/app/morphe/engine/util/BundleFormats.kt
+++ b/src/main/kotlin/app/morphe/engine/util/BundleFormats.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-cli
+ */
+
+package app.morphe.engine.util
+
+import java.io.File
+
+/**
+ * Split-APK bundle container formats — ZIP archives that hold a base APK plus
+ * config/density/abi split APKs (`.apkm` from APKMirror, `.xapk` from APKPure,
+ * `.apks` from bundletool/SAI).
+ *
+ * Single source of truth for "is this a bundle?" so the engine, GUI, and CLI
+ * all agree. Lives in `engine.util` because it's a pure data check with no UI
+ * or CLI dependencies, and the GUI/CLI both depend on the engine (not the
+ * reverse).
+ */
+object BundleFormats {
+    /** Bundle file extensions, lowercase, without the leading dot. */
+    val EXTENSIONS = setOf("apkm", "xapk", "apks")
+
+    /** True if [file]'s extension is a split-APK bundle format. */
+    fun isBundle(file: File): Boolean = file.extension.lowercase() in EXTENSIONS
+}

--- a/src/main/kotlin/app/morphe/gui/ui/components/SourceManagementSheet.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SourceManagementSheet.kt
@@ -642,14 +642,14 @@ private fun ChannelBadge(
     mono: androidx.compose.ui.text.font.FontFamily,
 ) {
     val corners = LocalMorpheCorners.current
-    val accents = LocalMorpheAccents.current
-    val (label, color) = when (channel) {
-        app.morphe.gui.util.EnabledSourcesLoader.Channel.STABLE_LATEST -> "STABLE LATEST" to accents.secondary
-        app.morphe.gui.util.EnabledSourcesLoader.Channel.STABLE_OLDER -> "STABLE OLDER" to accents.warning
-        app.morphe.gui.util.EnabledSourcesLoader.Channel.DEV_LATEST -> "DEV LATEST" to androidx.compose.ui.graphics.Color(0xFFFFD43B)
-        app.morphe.gui.util.EnabledSourcesLoader.Channel.DEV_OLDER -> "DEV OLDER" to accents.warning
-        else -> "STABLE LATEST" to accents.secondary
+    val label = when (channel) {
+        app.morphe.gui.util.EnabledSourcesLoader.Channel.STABLE_LATEST -> "STABLE LATEST"
+        app.morphe.gui.util.EnabledSourcesLoader.Channel.STABLE_OLDER -> "STABLE OLDER"
+        app.morphe.gui.util.EnabledSourcesLoader.Channel.DEV_LATEST -> "DEV LATEST"
+        app.morphe.gui.util.EnabledSourcesLoader.Channel.DEV_OLDER -> "DEV OLDER"
+        else -> "STABLE LATEST"
     }
+    val color = app.morphe.gui.ui.theme.channelColor(channel)
     Box(
         modifier = Modifier
             .border(1.dp, color.copy(alpha = 0.3f), RoundedCornerShape(corners.small))

--- a/src/main/kotlin/app/morphe/gui/ui/components/SourcesPill.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SourcesPill.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
@@ -36,11 +35,10 @@ import app.morphe.gui.ui.theme.LocalMorpheAccents
 import app.morphe.gui.ui.theme.LocalMorpheCorners
 import app.morphe.gui.ui.theme.LocalMorpheDimens
 import app.morphe.gui.ui.theme.LocalMorpheFont
-import app.morphe.gui.ui.theme.MorpheAccentColors
 import app.morphe.gui.util.EnabledSourcesLoader
 
 /** Per-source LED state surfaced in [SourcesCountPill]. */
-enum class SourceLedState { DISABLED, STABLE_LATEST, OLDER, DEV }
+enum class SourceLedState { DISABLED, STABLE_LATEST, STABLE_OLDER, DEV_LATEST, DEV_OLDER }
 
 /**
  * Header pill showing source count + per-source channel LEDs + trailing "+".
@@ -98,7 +96,7 @@ fun SourcesCountPill(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(3.dp),
             ) {
-                sourceStates.forEach { state -> SourceLed(state = state, accents = accents) }
+                sourceStates.forEach { state -> SourceLed(state = state) }
             }
         }
         if (interactive) {
@@ -113,12 +111,13 @@ fun SourcesCountPill(
 }
 
 @Composable
-private fun SourceLed(state: SourceLedState, accents: MorpheAccentColors) {
+private fun SourceLed(state: SourceLedState) {
     val color = when (state) {
         SourceLedState.DISABLED -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
-        SourceLedState.STABLE_LATEST -> accents.primary
-        SourceLedState.OLDER -> accents.warning
-        SourceLedState.DEV -> Color(0xFFFFD43B)
+        SourceLedState.STABLE_LATEST -> app.morphe.gui.ui.theme.channelColor(EnabledSourcesLoader.Channel.STABLE_LATEST)
+        SourceLedState.STABLE_OLDER -> app.morphe.gui.ui.theme.channelColor(EnabledSourcesLoader.Channel.STABLE_OLDER)
+        SourceLedState.DEV_LATEST -> app.morphe.gui.ui.theme.channelColor(EnabledSourcesLoader.Channel.DEV_LATEST)
+        SourceLedState.DEV_OLDER -> app.morphe.gui.ui.theme.channelColor(EnabledSourcesLoader.Channel.DEV_OLDER)
     }
     Box(
         modifier = Modifier
@@ -135,9 +134,9 @@ fun sourceLedState(
     if (!source.enabled) return SourceLedState.DISABLED
     return when (channel) {
         EnabledSourcesLoader.Channel.STABLE_LATEST -> SourceLedState.STABLE_LATEST
-        EnabledSourcesLoader.Channel.STABLE_OLDER -> SourceLedState.OLDER
-        EnabledSourcesLoader.Channel.DEV_LATEST,
-        EnabledSourcesLoader.Channel.DEV_OLDER -> SourceLedState.DEV
+        EnabledSourcesLoader.Channel.STABLE_OLDER -> SourceLedState.STABLE_OLDER
+        EnabledSourcesLoader.Channel.DEV_LATEST -> SourceLedState.DEV_LATEST
+        EnabledSourcesLoader.Channel.DEV_OLDER -> SourceLedState.DEV_OLDER
         // No load yet — assume latest until we know otherwise.
         null, EnabledSourcesLoader.Channel.UNKNOWN -> SourceLedState.STABLE_LATEST
     }

--- a/src/main/kotlin/app/morphe/gui/ui/theme/ChannelColors.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/theme/ChannelColors.kt
@@ -1,0 +1,32 @@
+package app.morphe.gui.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+import app.morphe.gui.util.EnabledSourcesLoader.Channel
+
+/**
+ * Semantic color for a patch source's release channel. Single source of truth so
+ * the source-card badge and the home-screen pill LED always agree.
+ *
+ * Two axes: channel (stable/dev) and recency (latest/older). Map to four distinct, intuitive hues:
+ *  - green (secondary)  stable + latest → recommended, current
+ *  - amber (warning)    stable + older  → safe channel, update available
+ *  - blue  (tertiary)   dev + latest    → experimental, on the newest build
+ *  - red   (error)      dev + older     → experimental AND behind, riskiest
+ *
+ * UNKNOWN / not-yet-loaded falls back to the "recommended" green.
+ */
+@Composable
+@ReadOnlyComposable
+fun channelColor(channel: Channel?): Color {
+    val accents = LocalMorpheAccents.current
+    return when (channel) {
+        Channel.STABLE_LATEST -> accents.secondary
+        Channel.STABLE_OLDER -> accents.warning
+        Channel.DEV_LATEST -> accents.tertiary
+        Channel.DEV_OLDER -> MaterialTheme.colorScheme.error
+        null, Channel.UNKNOWN -> accents.secondary
+    }
+}

--- a/src/main/kotlin/app/morphe/gui/util/FileUtils.kt
+++ b/src/main/kotlin/app/morphe/gui/util/FileUtils.kt
@@ -26,7 +26,7 @@ object FileUtils {
      */
     val ANDROID_ARCHITECTURES = setOf("arm64-v8a", "armeabi-v7a", "x86", "x86_64")
 
-    private val EXTENSION_APK_BUNDLES = setOf("apkm", "xapk", "apks")
+    private val EXTENSION_APK_BUNDLES = app.morphe.engine.util.BundleFormats.EXTENSIONS
     private val EXTENSION_APK_ANY = EXTENSION_APK_BUNDLES + "apk"
 
     /** Returns the unified Morphe data root. Was: per-OS app-data folder. */

--- a/src/main/kotlin/app/morphe/gui/util/PatchService.kt
+++ b/src/main/kotlin/app/morphe/gui/util/PatchService.kt
@@ -172,7 +172,14 @@ class PatchService {
             } finally {
                 tempCopies.forEach { runCatching { it.delete() } }
             }
-        } catch (e: Exception) {
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // Catch Throwable, not just Exception: a mismatched patch bundle can
+            // throw java.lang.Error (e.g. NoSuchMethodError when two sources ship
+            // the same class compiled against different patcher versions). Those
+            // are Errors, not Exceptions, so catch(Exception) would let them escape and the UI
+            // would hang on "Loading patches" forever instead of surfacing a failure.
             Logger.error("Patching failed", e)
             Result.failure(e)
         }


### PR DESCRIPTION
- The engine only merged `.apkm` bundles; `.xapk`/`.apks` were handed to the patcher unmerged and crashed with a null-manifest NPE. Fixed now.

- Older-stable, older-dev, and latest-dev all rendered as yellow/amber. That impossible to tell apart. Now four distinct colors ( 
  green = stable latest,
  amber = stable older,
  blue = dev latest,
  red = dev older
)
(If the color scheme feels off, please suggest better colors for indicating these things)

- Better patch load errors thrown.