### PR TITLE
feat: Patch sources follows latest (stable/dev) instead of to last used version

### DIFF
--- a/src/main/kotlin/app/morphe/gui/data/model/AppConfig.kt
+++ b/src/main/kotlin/app/morphe/gui/data/model/AppConfig.kt
@@ -25,24 +25,57 @@ val DEFAULT_PATCH_SOURCE = PatchSource(
     deletable = false
 )
 
+/**
+ * How a patch source decides which release to load.
+ *
+ * - [FOLLOW_STABLE]: ride the newest **stable** (non-pre-release) — auto-updates
+ *   as new stables ship. The default for an untouched source.
+ * - [FOLLOW_DEV]: ride the newest release **overall**, pre-releases included
+ *   ("bleeding edge"). When a dev is newest you get the dev; when a stable is the
+ *   newest thing out, you get that stable — without losing the dev track.
+ * - [PINNED]: stay frozen on one exact tag (chosen deliberately), ignoring newer
+ *   releases. The version lives in [SourceVersionPref.pinnedTag].
+ */
+@Serializable
+enum class FollowMode { FOLLOW_STABLE, FOLLOW_DEV, PINNED }
+
+/**
+ * A source's version preference: which release-tracking [mode], plus the exact
+ * tag when [mode] is [FollowMode.PINNED] (null otherwise).
+ */
+@Serializable
+data class SourceVersionPref(
+    val mode: FollowMode,
+    val pinnedTag: String? = null,
+)
+
 @Serializable
 data class AppConfig(
     val themePreference: String = ThemePreference.SYSTEM.name,
     val lastCliVersion: String? = null,
     /**
-     * LEGACY single-source version pin. Kept only for one-version migration into
-     * [lastPatchesVersionBySource] — read it on first load if the map is empty,
-     * then phase out. Do not read this directly anywhere new — go through
-     * [ConfigRepository.getLastPatchesVersionsBySource].
+     * LEGACY single-source version pin. Kept only so it can be migrated (via
+     * [lastPatchesVersionBySource]) into [sourceVersionPrefs]. Do not read directly
+     * anywhere new — go through [ConfigRepository.getSourceVersionPrefs].
      */
     val lastPatchesVersion: String? = null,
     /**
-     * Per-source version pin: sourceId → release tag. Absence of a key means
-     * "no pin — use that source's latest stable". Replaces the legacy single
-     * [lastPatchesVersion] which silently contaminated other sources whose tag
-     * names happened to overlap.
+     * LEGACY per-source version pin: sourceId → release tag. Superseded by
+     * [sourceVersionPrefs]; kept only so existing configs can migrate (every old
+     * tag becomes a follow-track based on whether it was a dev tag). Do not read
+     * directly — go through [ConfigRepository.getSourceVersionPrefs].
      */
     val lastPatchesVersionBySource: Map<String, String> = emptyMap(),
+    /**
+     * Per-source version preference: sourceId → [SourceVersionPref].
+     *
+     * Absence of a key = follow the source's latest stable (the default for a
+     * brand-new, untouched source). Otherwise the stored [SourceVersionPref]
+     * decides whether the source rides the latest stable, the latest overall
+     * (dev/bleeding-edge), or stays frozen on a specific tag. See
+     * [ConfigRepository.getSourceVersionPrefs] / [setSourceVersionPref].
+     */
+    val sourceVersionPrefs: Map<String, SourceVersionPref> = emptyMap(),
     val preferredPatchChannel: String = PatchChannel.STABLE.name,
     val defaultOutputDirectory: String? = null,
     val autoCleanupTempFiles: Boolean = true,  // Default ON

--- a/src/main/kotlin/app/morphe/gui/data/repository/ConfigRepository.kt
+++ b/src/main/kotlin/app/morphe/gui/data/repository/ConfigRepository.kt
@@ -8,6 +8,8 @@ package app.morphe.gui.data.repository
 import app.morphe.engine.util.PortablePaths
 import app.morphe.gui.data.model.AppConfig
 import app.morphe.gui.data.model.DEFAULT_PATCH_SOURCE
+import app.morphe.gui.data.model.FollowMode
+import app.morphe.gui.data.model.SourceVersionPref
 import app.morphe.gui.data.model.PatchChannel
 import app.morphe.gui.data.model.PatchSource
 import app.morphe.gui.data.model.UpdateChannelPreference
@@ -102,40 +104,48 @@ class ConfigRepository {
     }
 
     /**
-     * LEGACY — kept so single-source callers don't break during the multi-source
-     * transition. New code should use [setLastPatchesVersionForSource].
+     * Record a source's version preference (called by PatchesScreen when the user
+     * picks a release). Per-source, so sources with overlapping tag names don't
+     * contaminate each other.
      */
-    @Deprecated("Use setLastPatchesVersionForSource", ReplaceWith("setLastPatchesVersionForSource(sourceId, version)"))
-    suspend fun setLastPatchesVersion(version: String) {
+    suspend fun setSourceVersionPref(sourceId: String, pref: SourceVersionPref) {
         val current = loadConfig()
-        saveConfig(current.copy(lastPatchesVersion = version))
+        saveConfig(current.copy(sourceVersionPrefs = current.sourceVersionPrefs + (sourceId to pref)))
     }
 
     /**
-     * Pin a specific release tag for [sourceId]. Used by PatchesScreen when the
-     * user picks a version. Per-source = no cross-contamination across sources
-     * with overlapping tag names.
+     * Returns the per-source version preferences, with a one-time migration from
+     * the legacy tag-only fields ([AppConfig.lastPatchesVersionBySource] and the
+     * even-older single [AppConfig.lastPatchesVersion]).
+     *
+     * Migration intent: those legacy tags were auto-saved on every selection, not
+     * deliberate freezes, so we can't tell a real pin from "just used the latest."
+     * We therefore convert each old tag to a *follow track* based on whether it was
+     * a dev tag — `-dev` ⇒ [FollowMode.FOLLOW_DEV], else [FollowMode.FOLLOW_STABLE].
+     * Net effect: everyone shifts onto the latest of their channel (the fix), at the
+     * cost of un-freezing anyone who had deliberately pinned an old version (they can
+     * re-pin). A dev user parked on a stable tag at migration looks like a stable
+     * user and is migrated as such — an accepted, self-healing one-time loss.
      */
-    suspend fun setLastPatchesVersionForSource(sourceId: String, version: String) {
+    suspend fun getSourceVersionPrefs(): Map<String, SourceVersionPref> {
         val current = loadConfig()
-        val updated = current.lastPatchesVersionBySource + (sourceId to version)
-        saveConfig(current.copy(lastPatchesVersionBySource = updated))
-    }
+        if (current.sourceVersionPrefs.isNotEmpty()) return current.sourceVersionPrefs
 
-    /**
-     * Returns the per-source version pin map, with one-time migration from the
-     * legacy [AppConfig.lastPatchesVersion] field: if the map is empty and the
-     * legacy field is set, it's mapped to the default source.
-     */
-    suspend fun getLastPatchesVersionsBySource(): Map<String, String> {
-        val current = loadConfig()
-        if (current.lastPatchesVersionBySource.isNotEmpty()) {
-            return current.lastPatchesVersionBySource
+        // Build the legacy tag map (per-source map, or the single legacy field
+        // mapped onto the default source).
+        val legacyTags: Map<String, String> = when {
+            current.lastPatchesVersionBySource.isNotEmpty() -> current.lastPatchesVersionBySource
+            current.lastPatchesVersion != null -> mapOf(DEFAULT_PATCH_SOURCE.id to current.lastPatchesVersion!!)
+            else -> emptyMap()
         }
-        val legacy = current.lastPatchesVersion ?: return emptyMap()
-        // Migrate: write the legacy pin onto the default source, return the new map.
-        val migrated = mapOf(DEFAULT_PATCH_SOURCE.id to legacy)
-        saveConfig(current.copy(lastPatchesVersionBySource = migrated))
+        if (legacyTags.isEmpty()) return emptyMap()
+
+        val migrated = legacyTags.mapValues { (_, tag) ->
+            val mode = if (tag.contains("-dev", ignoreCase = true)) FollowMode.FOLLOW_DEV
+                       else FollowMode.FOLLOW_STABLE
+            SourceVersionPref(mode = mode)
+        }
+        saveConfig(current.copy(sourceVersionPrefs = migrated))
         return migrated
     }
 

--- a/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeViewModel.kt
@@ -13,6 +13,7 @@ import app.morphe.engine.UpdateInfo
 import app.morphe.engine.model.PatchedAppRecord
 import app.morphe.engine.util.SignatureIdentity
 import app.morphe.gui.data.model.Patch
+import app.morphe.gui.data.model.SourceVersionPref
 import app.morphe.gui.data.model.SupportedApp
 import app.morphe.gui.data.repository.ConfigRepository
 import app.morphe.gui.data.repository.PatchRepository
@@ -347,7 +348,7 @@ class HomeViewModel(
     private var lastLoadedVersion: String? = null
     // Snapshot of per-source pinned versions used in the last load — drives
     // refreshPatchesIfNeeded so we reload when ANY source's pin changes.
-    private var lastLoadedVersionsBySource: Map<String, String> = emptyMap()
+    private var lastLoadedVersionsBySource: Map<String, SourceVersionPref> = emptyMap()
 
     /**
      * Load patches from all enabled sources via [EnabledSourcesLoader] and build
@@ -372,9 +373,9 @@ class HomeViewModel(
                 // Per-source pinned versions (with one-time migration from legacy
                 // single-source field). Each source's resolver looks up its own pin;
                 // no cross-source contamination.
-                val preferredVersions = configRepository.getLastPatchesVersionsBySource()
-                lastLoadedVersionsBySource = preferredVersions
-                val result = EnabledSourcesLoader.loadAll(enabled, patchService, preferredVersions)
+                val prefs = configRepository.getSourceVersionPrefs()
+                lastLoadedVersionsBySource = prefs
+                val result = EnabledSourcesLoader.loadAll(enabled, patchService, prefs)
 
                 if (!result.anyLoaded) {
                     val firstError = result.resolved.firstNotNullOfOrNull { it.error }
@@ -780,7 +781,7 @@ class HomeViewModel(
      */
     fun refreshPatchesIfNeeded() {
         screenModelScope.launch {
-            val saved = configRepository.getLastPatchesVersionsBySource()
+            val saved = configRepository.getSourceVersionPrefs()
             if (saved != lastLoadedVersionsBySource) {
                 Logger.info("Patches versions changed across sources: $lastLoadedVersionsBySource -> $saved, reloading...")
                 loadPatchesAndSupportedApps(forceRefresh = true)

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchesViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchesViewModel.kt
@@ -10,6 +10,8 @@ import app.morphe.patcher.patch.loadPatchesFromJar
 import cafe.adriel.voyager.core.model.ScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import app.morphe.engine.model.Release
+import app.morphe.gui.data.model.FollowMode
+import app.morphe.gui.data.model.SourceVersionPref
 import app.morphe.gui.data.repository.ConfigRepository
 import app.morphe.gui.data.repository.PatchRepository
 import app.morphe.gui.data.repository.PatchSourceManager
@@ -81,10 +83,16 @@ class PatchesViewModel(
                     val stableReleases = releases.filter { !it.isDevRelease() }
                     val devReleases = releases.filter { it.isDevRelease() }
 
-                    // Check config for previously selected version FOR THIS SOURCE
+                    // Resolve this source's version preference to a concrete tag
+                    // to pre-select: a pin → its tag; follow-stable → newest stable;
+                    // follow-dev → newest overall.
                     val activeSourceId = patchSourceManager?.getActiveSource()?.id
-                    val savedVersion = activeSourceId?.let {
-                        configRepository.getLastPatchesVersionsBySource()[it]
+                    val pref = activeSourceId?.let { configRepository.getSourceVersionPrefs()[it] }
+                    val savedVersion = when (pref?.mode) {
+                        FollowMode.PINNED -> pref.pinnedTag
+                        FollowMode.FOLLOW_STABLE -> stableReleases.firstOrNull()?.tagName
+                        FollowMode.FOLLOW_DEV -> releases.firstOrNull()?.tagName
+                        null -> null
                     }
 
                     // Find the saved release, or fall back to latest stable
@@ -137,8 +145,12 @@ class PatchesViewModel(
                                     .fold(0L) { acc, part -> acc * 10000 + part }
                             }
                         val activeSourceId = patchSourceManager?.getActiveSource()?.id
-                        val savedVersion = activeSourceId?.let {
-                            configRepository.getLastPatchesVersionsBySource()[it]
+                        val pref = activeSourceId?.let { configRepository.getSourceVersionPrefs()[it] }
+                        val savedVersion = when (pref?.mode) {
+                            FollowMode.PINNED -> pref.pinnedTag
+                            FollowMode.FOLLOW_STABLE -> offlineReleases.firstOrNull { !it.isDevRelease() }?.tagName
+                            FollowMode.FOLLOW_DEV -> offlineReleases.firstOrNull()?.tagName
+                            null -> null
                         }
 
                         // Pre-select the saved version, or fall back to the first (most recent)
@@ -306,12 +318,13 @@ class PatchesViewModel(
                     )
                     Logger.info("Patches downloaded: ${patchFile.absolutePath}")
 
-                    // Save the selected version PER SOURCE so HomeScreen can pick it up
-                    // without contaminating other enabled sources.
+                    // Save the version preference PER SOURCE so HomeScreen can pick
+                    // it up without contaminating other enabled sources.
                     val activeSourceId = patchSourceManager?.getActiveSource()?.id
                     if (activeSourceId != null) {
-                        configRepository.setLastPatchesVersionForSource(activeSourceId, release.tagName)
-                        Logger.info("Saved selected patches version for source '$activeSourceId': ${release.tagName}")
+                        val pref = versionPrefFor(release)
+                        configRepository.setSourceVersionPref(activeSourceId, pref)
+                        Logger.info("Saved version pref for source '$activeSourceId': $pref")
                     }
                 },
                 onFailure = { e ->
@@ -338,10 +351,31 @@ class PatchesViewModel(
         screenModelScope.launch {
             val activeSourceId = patchSourceManager?.getActiveSource()?.id
             if (activeSourceId != null) {
-                configRepository.setLastPatchesVersionForSource(activeSourceId, release.tagName)
-                Logger.info("Confirmed patches selection for source '$activeSourceId': ${release.tagName}")
+                val pref = versionPrefFor(release)
+                configRepository.setSourceVersionPref(activeSourceId, pref)
+                Logger.info("Confirmed version pref for source '$activeSourceId': $pref")
             }
         }
+    }
+
+    /**
+     * Turn a user-selected release into a [SourceVersionPref]:
+     *  - the newest stable  → [FollowMode.FOLLOW_STABLE] (ride latest stable)
+     *  - the newest dev      → [FollowMode.FOLLOW_DEV] (ride newest overall)
+     *  - anything older      → [FollowMode.PINNED] to that exact tag
+     *
+     * "Picked the latest of a channel" is read as "stay on that channel's latest,"
+     * which is what auto-updates the source going forward.
+     */
+    private fun versionPrefFor(release: Release): SourceVersionPref {
+        val newestStableTag = _uiState.value.stableReleases.firstOrNull()?.tagName
+        val newestDevTag = _uiState.value.devReleases.firstOrNull()?.tagName
+        val mode = when {
+            release.isDevRelease() && release.tagName == newestDevTag -> FollowMode.FOLLOW_DEV
+            !release.isDevRelease() && release.tagName == newestStableTag -> FollowMode.FOLLOW_STABLE
+            else -> FollowMode.PINNED
+        }
+        return SourceVersionPref(mode = mode, pinnedTag = release.tagName.takeIf { mode == FollowMode.PINNED })
     }
 
     /**

--- a/src/main/kotlin/app/morphe/gui/util/EnabledSourcesLoader.kt
+++ b/src/main/kotlin/app/morphe/gui/util/EnabledSourcesLoader.kt
@@ -6,8 +6,10 @@
 package app.morphe.gui.util
 
 import app.morphe.engine.MultiSourceLoader
+import app.morphe.gui.data.model.FollowMode
 import app.morphe.gui.data.model.PatchSource
 import app.morphe.gui.data.model.PatchSourceType
+import app.morphe.gui.data.model.SourceVersionPref
 import app.morphe.gui.data.repository.PatchRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -79,7 +81,7 @@ object EnabledSourcesLoader {
     suspend fun loadAll(
         enabled: List<Pair<PatchSource, PatchRepository?>>,
         patchService: PatchService,
-        preferredVersionsBySource: Map<String, String> = emptyMap(),
+        prefsBySource: Map<String, SourceVersionPref> = emptyMap(),
     ): Result = supervisorScope {
         // supervisorScope (not coroutineScope) so a single source's failure
         // doesn't cancel the other in-flight resolves. Each async catches its
@@ -89,7 +91,7 @@ object EnabledSourcesLoader {
         val resolved = enabled.map { (source, repo) ->
             async(Dispatchers.IO) {
                 try {
-                    resolve(source, repo, preferredVersionsBySource[source.id])
+                    resolve(source, repo, prefsBySource[source.id])
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -136,7 +138,7 @@ object EnabledSourcesLoader {
     private suspend fun resolve(
         source: PatchSource,
         repo: PatchRepository?,
-        preferredVersion: String?,
+        pref: SourceVersionPref?,
     ): ResolvedSource = withContext(Dispatchers.IO) {
         when (source.type) {
             PatchSourceType.LOCAL -> resolveLocal(source)
@@ -145,7 +147,7 @@ object EnabledSourcesLoader {
             // which API to talk to based on the source's provider type.
             PatchSourceType.DEFAULT,
             PatchSourceType.GITHUB,
-            PatchSourceType.GITLAB -> resolveRemote(source, repo, preferredVersion)
+            PatchSourceType.GITLAB -> resolveRemote(source, repo, pref)
         }
     }
 
@@ -169,7 +171,7 @@ object EnabledSourcesLoader {
     private suspend fun resolveRemote(
         source: PatchSource,
         repo: PatchRepository?,
-        preferredVersion: String?,
+        pref: SourceVersionPref?,
     ): ResolvedSource {
         if (repo == null) {
             return ResolvedSource(source = source, error = "No repository configured for source")
@@ -193,17 +195,23 @@ object EnabledSourcesLoader {
             return ResolvedSource(source = source, error = errMsg)
         }
 
-        // Honor a user-pinned version if it exists in this source's releases.
-        // Otherwise pick latest stable, falling back to latest dev.
-        val release = preferredVersion
-            ?.let { pinned -> releases.find { it.tagName == pinned } }
-            ?: releases.firstOrNull { !it.isDevRelease() }
-            ?: releases.firstOrNull()
-            ?: return ResolvedSource(source = source, error = "No releases found")
+        // Resolve which release to load from this source's version preference:
+        //  - PINNED        → the exact tag (fall back to latest stable if it's gone)
+        //  - FOLLOW_DEV    → newest release overall, pre-releases included
+        //  - FOLLOW_STABLE → newest stable (also the default when there's no pref)
+        // The release list is newest-first, so firstOrNull() is the newest overall.
+        val latestStable = releases.firstOrNull { !it.isDevRelease() }
+        val latestOverall = releases.firstOrNull()
+        val release = when (pref?.mode) {
+            FollowMode.PINNED ->
+                releases.find { it.tagName == pref.pinnedTag } ?: latestStable ?: latestOverall
+            FollowMode.FOLLOW_DEV -> latestOverall ?: latestStable
+            FollowMode.FOLLOW_STABLE, null -> latestStable ?: latestOverall
+        } ?: return ResolvedSource(source = source, error = "No releases found")
 
-        // Classify against this source's release list so the LED + badge can
-        // distinguish "latest stable" from "older stable" from "dev".
-        val latestStableTag = releases.firstOrNull { !it.isDevRelease() }?.tagName
+        // Classify where the resolved release actually sits (for the LED + badge),
+        // independent of which track it's following.
+        val latestStableTag = latestStable?.tagName
         val latestDevTag = releases.firstOrNull { it.isDevRelease() }?.tagName
         val channel = when {
             release.isDevRelease() && release.tagName == latestDevTag -> Channel.DEV_LATEST


### PR DESCRIPTION
On startup, the gui automatically gets the latest version of dev/stable if available based on user's previous choice and shifts to it. An older version is pinned only if the user had previously pinned an older version.

!Important: Existing sources are moved onto the latest of their channel. Anyone who had deliberately pinned an older version will be bumped to latest. Users will need to re-pin for now.