### PR TITLE
feat: Add `--include-experimental` flag to `list-patches` and `list-versions`

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/ListCompatibleVersions.kt
+++ b/src/main/kotlin/app/morphe/cli/command/ListCompatibleVersions.kt
@@ -5,11 +5,11 @@
 
 package app.morphe.cli.command
 
+import app.morphe.engine.CompatibleVersionsMap
 import app.morphe.engine.MorpheData
-import app.morphe.patcher.patch.PackageName
-import app.morphe.patcher.patch.VersionMap
+import app.morphe.engine.VersionMap
+import app.morphe.engine.mostCommonCompatibleVersions
 import app.morphe.patcher.patch.loadPatchesFromJar
-import app.morphe.patcher.patch.mostCommonCompatibleVersions
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Help.Visibility.ALWAYS
@@ -62,6 +62,13 @@ internal class ListCompatibleVersions : Runnable {
     private var countUnusedPatches: Boolean = false
 
     @Option(
+        names = ["-x", "--include-experimental"],
+        description = ["Include experimental app versions in the output."],
+        showDefaultValue = ALWAYS,
+    )
+    private var includeExperimental: Boolean = false
+
+    @Option(
         names = ["-t", "--temporary-files-path"],
         description = ["Path to store temporary files."],
     )
@@ -81,7 +88,7 @@ internal class ListCompatibleVersions : Runnable {
             }
         }
 
-        fun buildString(entry: Map.Entry<PackageName, VersionMap>) =
+        fun buildString(entry: Map.Entry<String, VersionMap>) =
             buildString {
                 val (name, versions) = entry
                 appendLine("Package name: $name")
@@ -110,6 +117,7 @@ internal class ListCompatibleVersions : Runnable {
         patches.mostCommonCompatibleVersions(
             packageNames,
             countUnusedPatches,
+            includeExperimental,
         ).entries.joinToString("\n", transform = ::buildString).let(logger::info)
     }
 }

--- a/src/main/kotlin/app/morphe/cli/command/ListPatchesCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/ListPatchesCommand.kt
@@ -9,7 +9,8 @@
 package app.morphe.cli.command
 
 import app.morphe.engine.MorpheData
-import app.morphe.patcher.patch.Package
+import app.morphe.engine.compatibleVersionsForDisplay
+import app.morphe.engine.isCompatibleWith
 import app.morphe.patcher.patch.Patch
 import app.morphe.patcher.patch.loadPatchesFromJar
 import picocli.CommandLine
@@ -109,24 +110,17 @@ internal object ListPatchesCommand : Runnable {
     )
     private var packageName: String? = null
 
+    @Option(
+        names = ["-x", "--include-experimental"],
+        description = ["Include experimental app versions in the output."],
+        showDefaultValue = ALWAYS,
+    )
+    private var includeExperimental: Boolean = false
+
     @Spec
     private lateinit var spec: CommandSpec
 
     override fun run() {
-        fun Package.buildString(): String {
-            val (name, versions) = this
-
-            return buildString {
-                if (withVersions && versions != null) {
-                    appendLine("Package name: $name")
-                    appendLine("Compatible versions:")
-                    append(versions.joinToString("\n") { version -> version }.prependIndent("\t"))
-                } else {
-                    append("Package name: $name")
-                }
-            }
-        }
-
         fun PatchOption<*>.buildString() =
             buildString {
                 appendLine("Title: $title")
@@ -165,21 +159,35 @@ internal object ListPatchesCommand : Runnable {
                         )
                     }
 
-                    if (withPackages && patch.compatiblePackages != null) {
-                        appendLine("\nCompatible packages:")
-                        append(
-                            patch.compatiblePackages!!.joinToString("\n") {
-                                it.buildString()
-                            }.prependIndent("\t"),
-                        )
+                    if (withPackages) {
+                        val packages = patch.compatibleVersionsForDisplay(includeExperimental)
+                        if (packages.isNotEmpty()) {
+                            appendLine("\nCompatible packages:")
+                            append(
+                                packages.joinToString("\n") { (name, versions) ->
+                                    buildString {
+                                        val displayName = name ?: "(universal)"
+                                        if (withVersions && versions.isNotEmpty()) {
+                                            appendLine("Package name: $displayName")
+                                            appendLine("Compatible versions:")
+                                            append(versions.joinToString("\n").prependIndent("\t"))
+                                        } else {
+                                            append("Package name: $displayName")
+                                        }
+                                    }
+                                }.prependIndent("\t"),
+                            )
+                        }
                     }
                 }
             }
 
         fun Patch<*>.filterCompatiblePackages(name: String) =
-            compatiblePackages?.any { (compatiblePackageName, _) ->
-                compatiblePackageName == name
-            } ?: withUniversalPatches
+            isCompatibleWith(
+                packageName = name,
+                includeExperimental = includeExperimental,
+                includeUniversalPatches = withUniversalPatches,
+            )
 
 
         val temporaryFilesPath = temporaryFilesPath ?: MorpheData.tmpDir

--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -12,6 +12,7 @@ import app.morphe.cli.command.model.*
 import app.morphe.engine.MorpheData
 import app.morphe.engine.PatchEngine
 import app.morphe.engine.isWindows
+import app.morphe.engine.supportedVersionsFor
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_KEYSTORE_ALIAS
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_KEYSTORE_PASSWORD
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_SIGNER_NAME
@@ -673,8 +674,13 @@ internal object PatchCommand : Callable<Int> {
 
                         val compatiblePatchNames = bundlePatches
                             .filter { patch ->
-                                patch.compatiblePackages == null ||
-                                    patch.compatiblePackages!!.any { (name, _) -> name == packageName }
+                                val compat = patch.compatibility
+                                if (!compat.isNullOrEmpty()) {
+                                    compat.any { it.packageName == packageName || it.packageName == null }
+                                } else {
+                                    @Suppress("DEPRECATION")
+                                    patch.compatiblePackages == null || patch.compatiblePackages!!.any { (name, _) -> name == packageName }
+                                }
                             }
                             .mapNotNull { it.name?.lowercase() }
                             .toSet()
@@ -701,11 +707,15 @@ internal object PatchCommand : Callable<Int> {
 
                             // Compare against the live patch in this bundle (not the snapshot)
                             // so multi-app patches with the same name aren't merged together.
-                            val actualPatch = bundlePatches.find {
-                                it.name.equals(patchName, ignoreCase = true) &&
-                                    (it.compatiblePackages == null || it.compatiblePackages!!.any {
-                                        (name, _) -> name == packageName
-                                    })
+                            val actualPatch = bundlePatches.find { patch ->
+                                if (!patch.name.equals(patchName, ignoreCase = true)) return@find false
+                                val compat = patch.compatibility
+                                if (!compat.isNullOrEmpty()) {
+                                    compat.any { it.packageName == packageName || it.packageName == null }
+                                } else {
+                                    @Suppress("DEPRECATION")
+                                    patch.compatiblePackages == null || patch.compatiblePackages!!.any { (name, _) -> name == packageName }
+                                }
                             }
                             val actualOptionKeys = actualPatch?.options?.keys ?: emptySet()
 
@@ -1019,34 +1029,31 @@ internal object PatchCommand : Callable<Int> {
             val patchNameLower = patchName.lowercase()
 
             // Check package compatibility first to avoid duplicate logs for multi-app patches.
-            patch.compatiblePackages?.let { packages ->
-                packages.singleOrNull { (name, _) -> name == packageName }?.let { (_, versions) ->
-                    if (versions?.isEmpty() == true) {
-                        return@patchLoop logger.warning(
-                            "Skipping \"$patchName\": incompatible with $packageName"
-                        )
-                    }
-
-                    val matchesVersion =
-                        force || versions?.let { it.any { version -> version == packageVersion } } ?: true
-
+            val supportedVersions = patch.supportedVersionsFor(packageName)
+            when {
+                supportedVersions != null && supportedVersions.isEmpty() -> {
+                    return@patchLoop logger.fine(
+                        "Skipping \"$patchName\": incompatible with $packageName " +
+                            "(only compatible with " +
+                            (patch.compatibility
+                                ?.mapNotNull { it.packageName }
+                                ?.joinToString(", ")
+                                ?: @Suppress("DEPRECATION") patch.compatiblePackages
+                                    ?.joinToString(", ") { (name, _) -> name }
+                                ?: "") + ")"
+                    )
+                }
+                supportedVersions != null -> {
+                    val matchesVersion = force || packageVersion in supportedVersions
                     if (!matchesVersion) {
-                        val compatibilityHint = packages.joinToString("; ") { (pkg, vers) ->
-                            pkg + " " + (vers ?: emptySet()).joinToString(", ")
-                        }
+                        val hint = supportedVersions.joinToString(", ")
                         return@patchLoop logger.warning(
                             "Skipping \"$patchName\": incompatible with $packageName $packageVersion " +
-                                "(supported: $compatibilityHint)"
+                                "(supported: $packageName $hint)"
                         )
                     }
-                } ?: return@patchLoop logger.fine(
-                    "Skipping \"$patchName\": incompatible with $packageName " +
-                        "(only compatible with " +
-                        packages.joinToString(", ") { (name, _) -> name } + ")"
-                )
-
-                return@let
-            } ?: logger.fine("\"$patchName\" has no package constraints")
+                }
+            }
 
             // CLI flags take precedence over JSON, JSON takes precedence over defaults.
             // Log strings match the GUI engine's "Skipping disabled: …" format so
@@ -1075,7 +1082,7 @@ internal object PatchCommand : Callable<Int> {
 
             val isJsonEnabled = patchNameLower in jsonEnabledPatches
 
-            val isEnabled = !exclusive && patch.use
+            val isEnabled = !exclusive && patch.default
 
             if (!(isEnabled || isCliEnabled || isJsonEnabled)) {
                 // Default-disabled patches (the patch ships with use=false and

--- a/src/main/kotlin/app/morphe/engine/PatchEngine.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchEngine.kt
@@ -320,23 +320,15 @@ object PatchEngine {
             val patchName = patch.name ?: return@patchLoop
 
             // Check package compatibility first to avoid duplicate logs for multi-app patches.
-            patch.compatiblePackages?.let { packages ->
-                val matchingPkg = packages.singleOrNull { (name, _) -> name == packageName }
-                if (matchingPkg == null) {
-                    return@patchLoop
-                }
-
-                val (_, versions) = matchingPkg
-                if (versions?.isEmpty() == true) {
-                    return@patchLoop
-                }
-
-                val matchesVersion = forceCompatibility ||
-                        versions?.any { it == packageVersion } ?: true
-
-                if (!matchesVersion) {
-                    onProgress("Skipping \"$patchName\": incompatible with $packageName $packageVersion")
-                    return@patchLoop
+            val supportedVersions = patch.supportedVersionsFor(packageName)
+            when {
+                supportedVersions != null && supportedVersions.isEmpty() -> return@patchLoop
+                supportedVersions != null -> {
+                    val matchesVersion = forceCompatibility || packageVersion in supportedVersions
+                    if (!matchesVersion) {
+                        onProgress("Skipping \"$patchName\": incompatible with $packageName $packageVersion")
+                        return@patchLoop
+                    }
                 }
             }
 
@@ -347,7 +339,7 @@ object PatchEngine {
             }
 
             val isManuallyEnabled = patchName in enabledPatches
-            val isEnabledByDefault = !exclusiveMode && patch.use
+            val isEnabledByDefault = !exclusiveMode && patch.default
 
             if (!(isEnabledByDefault || isManuallyEnabled)) {
                 return@patchLoop

--- a/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-cli
+ */
+
+package app.morphe.engine
+
+import app.morphe.patcher.patch.Patch
+
+typealias VersionMap = LinkedHashMap<String, Int>
+typealias CompatibleVersionsMap = Map<String, VersionMap>
+
+
+@Suppress("DEPRECATION")
+fun Patch<*>.versionsFor(
+    packageName: String?,
+    includeExperimental: Boolean,
+): List<String> {
+    val compat = compatibility
+
+    if (!compat.isNullOrEmpty()) {
+        val matchingEntries = compat.filter { entry ->
+            packageName == null || entry.packageName == null || entry.packageName == packageName
+        }
+        return matchingEntries.flatMap { entry ->
+            entry.targets
+                .filter { target -> includeExperimental || !target.isExperimental }
+                .mapNotNull { it.version }
+        }
+    }
+
+    val legacyPackages = compatiblePackages ?: return emptyList()
+    val matchingPkgs = if (packageName == null) {
+        legacyPackages
+    } else {
+        legacyPackages.filter { (name, _) -> name == packageName }
+    }
+    return matchingPkgs.flatMap { (_, versions) -> versions?.toList() ?: emptyList() }
+}
+
+
+@Suppress("DEPRECATION")
+fun Patch<*>.isCompatibleWith(
+    packageName: String,
+    includeExperimental: Boolean,
+    includeUniversalPatches: Boolean,
+): Boolean {
+    val compat = compatibility
+
+    if (!compat.isNullOrEmpty()) {
+        return compat.any { entry ->
+            when {
+                entry.packageName == null -> includeUniversalPatches
+                entry.packageName != packageName -> false
+                else -> {
+                    entry.targets.any { target ->
+                        includeExperimental || !target.isExperimental
+                    }
+                }
+            }
+        }
+    }
+
+    val legacyPackages = compatiblePackages
+        ?: return includeUniversalPatches
+
+    return legacyPackages.any { (name, _) -> name == packageName }
+}
+
+
+@Suppress("DEPRECATION")
+fun Patch<*>.compatibleVersionsForDisplay(
+    includeExperimental: Boolean,
+): List<Pair<String?, List<String>>> {
+    val compat = compatibility
+
+    if (!compat.isNullOrEmpty()) {
+        return compat.map { entry ->
+            val versions = entry.targets
+                .filter { includeExperimental || !it.isExperimental }
+                .mapNotNull { it.version }
+            entry.packageName to versions
+        }
+    }
+
+    val legacyPackages = compatiblePackages ?: return emptyList()
+    return legacyPackages.map { (name, versions) ->
+        name to (versions?.toList() ?: emptyList())
+    }
+}
+
+@Suppress("DEPRECATION")
+fun Iterable<Patch<*>>.mostCommonCompatibleVersions(
+    packageNames: Set<String>?,
+    countUnusedPatches: Boolean,
+    includeExperimental: Boolean = false,
+): CompatibleVersionsMap {
+    val allPackageNames: Set<String> = buildSet {
+        for (patch in this@mostCommonCompatibleVersions) {
+            val compat = patch.compatibility
+            if (!compat.isNullOrEmpty()) {
+                for (entry in compat) {
+                    entry.packageName?.let { add(it) }
+                }
+            } else {
+                @Suppress("DEPRECATION")
+                patch.compatiblePackages?.forEach { (name, _) -> add(name) }
+            }
+        }
+    }
+
+    val targetPackages = if (packageNames != null) {
+        allPackageNames.intersect(packageNames)
+    } else {
+        allPackageNames
+    }
+
+    val result: MutableMap<String, VersionMap> = LinkedHashMap()
+
+    for (pkgName in targetPackages) {
+        val versionCount = VersionMap()
+
+        for (patch in this) {
+            if (!countUnusedPatches && !patch.use) continue
+
+            val compat = patch.compatibility
+
+            if (!compat.isNullOrEmpty()) {
+                val isUniversal = compat.all { it.packageName == null }
+                val matchingEntries = compat.filter { entry ->
+                    entry.packageName == null || entry.packageName == pkgName
+                }
+
+                if (matchingEntries.isEmpty()) continue
+
+                val versions = matchingEntries.flatMap { entry ->
+                    entry.targets
+                        .filter { includeExperimental || !it.isExperimental }
+                        .mapNotNull { it.version }
+                }
+
+                if (versions.isEmpty() && !isUniversal) continue
+
+                if (versions.isEmpty()) {
+                    versionCount[""] = (versionCount[""] ?: 0) + 1
+                } else {
+                    for (version in versions) {
+                        versionCount[version] = (versionCount[version] ?: 0) + 1
+                    }
+                }
+            } else {
+                @Suppress("DEPRECATION")
+                val legacyPackages = patch.compatiblePackages
+                if (legacyPackages == null) {
+                    versionCount[""] = (versionCount[""] ?: 0) + 1
+                    continue
+                }
+                val matching = legacyPackages.filter { (name, _) -> name == pkgName }
+                if (matching.isEmpty()) continue
+                for ((_, versions) in matching) {
+                    if (versions.isNullOrEmpty()) {
+                        versionCount[""] = (versionCount[""] ?: 0) + 1
+                    } else {
+                        for (version in versions) {
+                            versionCount[version] = (versionCount[version] ?: 0) + 1
+                        }
+                    }
+                }
+            }
+        }
+
+        if (versionCount.isNotEmpty()) {
+            val sorted = versionCount.entries
+                .sortedByDescending { it.value }
+                .associateTo(LinkedHashMap()) { it.key to it.value }
+            sorted.remove("")
+            result[pkgName] = sorted
+        }
+    }
+
+    return result.entries
+        .sortedBy { it.key }
+        .associateTo(LinkedHashMap()) { it.key to it.value }
+}

--- a/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
@@ -38,7 +38,6 @@ fun Patch<*>.versionsFor(
     return matchingPkgs.flatMap { (_, versions) -> versions?.toList() ?: emptyList() }
 }
 
-
 @Suppress("DEPRECATION")
 fun Patch<*>.isCompatibleWith(
     packageName: String,
@@ -67,6 +66,25 @@ fun Patch<*>.isCompatibleWith(
     return legacyPackages.any { (name, _) -> name == packageName }
 }
 
+@Suppress("DEPRECATION")
+fun Patch<*>.supportedVersionsFor(packageName: String): List<String>? {
+    val compat = compatibility
+
+    if (!compat.isNullOrEmpty()) {
+        val matching = compat.filter { it.packageName == packageName }
+        if (matching.isEmpty()) {
+            val hasUniversalEntry = compat.any { it.packageName == null }
+            return if (hasUniversalEntry) null else emptyList()
+        }
+        return matching.flatMap { entry -> entry.targets.mapNotNull { it.version } }
+    }
+
+    val legacyPackages = compatiblePackages ?: return null
+    val match = legacyPackages.singleOrNull { (name, _) -> name == packageName }
+        ?: return emptyList()
+    val legacyVersions = match.second
+    return if (legacyVersions.isNullOrEmpty()) null else legacyVersions.toList()
+}
 
 @Suppress("DEPRECATION")
 fun Patch<*>.compatibleVersionsForDisplay(


### PR DESCRIPTION
Closes #171.

Adds `-x` / `--include-experimental` to both `list-patches` and `list-versions`. Without it, the output is identical to before.

The old `compatiblePackages` API has no concept of experimental versions, everything gets flattened. The new `compatibility` API has an `isExperimental` flag per version target, so we now use that as the source of truth, with a fallback to the legacy field for older patch bundles. The filtering/rendering logic lives in a new `PatchExtensions.kt` in `app.morphe.engine` to keep it out of the command classes.

**`list-patches -p -v -x`** now shows experimental versions under "Compatible versions" and labels universal patches as `(universal)` instead of silently dropping them. **`list-versions -x`** now counts experimental versions in the frequency table:

```
$ java -jar cli.jar list-versions --patches=patches.mpp -x
Package name: com.google.android.youtube
Most common compatible versions:
        21.25.523 (70 patches)
        21.24.360 (70 patches)
        ...
```