### PR TITLE
fix: Allow patches with empty targets to apply automatically

### DIFF
--- a/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
@@ -76,7 +76,8 @@ fun Patch<*>.supportedVersionsFor(packageName: String): List<String>? {
             val hasUniversalEntry = compat.any { it.packageName == null }
             return if (hasUniversalEntry) null else emptyList()
         }
-        return matching.flatMap { entry -> entry.targets.mapNotNull { it.version } }
+        val versions = matching.flatMap { entry -> entry.targets.mapNotNull { it.version } }
+        return versions.ifEmpty { null }
     }
 
     val legacyPackages = compatiblePackages ?: return null


### PR DESCRIPTION
Closes #204.

Fixes a regression introduced during the migration to the new `patch.compatibility` API.