### PR TITLE
fix: fix patch repo rate limiting by switching to raw links + stream downloads to disk

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/CliHttpClient.kt
+++ b/src/main/kotlin/app/morphe/cli/command/CliHttpClient.kt
@@ -7,6 +7,7 @@ package app.morphe.cli.command
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -22,6 +23,16 @@ object CliHttpClient {
         HttpClient(CIO) {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
+            }
+            // Idle/socket timeouts (not a total cap) so large .mpp downloads don't fail
+            // for being big. Only genuine stalls or issues fail. Default CIO requestTimeout is 15s.
+            install(HttpTimeout) {
+                connectTimeoutMillis = 30_000
+                socketTimeoutMillis = 60_000
+            }
+            // Retry/429 handling lives in HttpService (single layer), not a client plugin.
+            engine {
+                requestTimeout = 0
             }
         }
     }

--- a/src/main/kotlin/app/morphe/engine/model/PatchesBundle.kt
+++ b/src/main/kotlin/app/morphe/engine/model/PatchesBundle.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-cli
+ */
+
+package app.morphe.engine.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The `patches-bundle.json` a patch repo publishes at its root (branch `main` = stable,
+ * `dev` = prerelease). Read via the **raw CDN** (`raw.githubusercontent.com` / GitLab
+ * raw) so resolving the latest patch doesn't spend a call against the rate-limited
+ * releases API.
+ *
+ * Mirrors morphe manager's `PatchesReleaseInfo`.
+ */
+@Serializable
+data class PatchesBundle(
+    val version: String,
+    @SerialName("download_url") val downloadUrl: String,
+    @SerialName("created_at") val createdAt: String? = null,
+    val description: String? = null,
+    @SerialName("signature_download_url") val signatureDownloadUrl: String? = null,
+) {
+    /** Adapt to the shared [Release] model so the rest of the pipeline is unchanged. */
+    fun toRelease(prerelease: Boolean): Release {
+        val assetName = downloadUrl.substringAfterLast('/').ifBlank { "patches-$version.mpp" }
+        return Release(
+            tagName = if (version.startsWith("v", ignoreCase = true)) version else "v$version",
+            isPrerelease = prerelease,
+            createdAt = createdAt,
+            body = description,
+            assets = listOf(ReleaseAsset(name = assetName, downloadUrl = downloadUrl)),
+        )
+    }
+}

--- a/src/main/kotlin/app/morphe/engine/network/HttpService.kt
+++ b/src/main/kotlin/app/morphe/engine/network/HttpService.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-cli
+ */
+
+package app.morphe.engine.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.get
+import io.ktor.client.request.head
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.logging.Logger
+
+/**
+ * Central HTTP layer for the desktop/JVM engine, wrapping a shared Ktor
+ * [HttpClient]. Both [GitHubPatchSource][app.morphe.engine.patches.GitHubPatchSource]
+ * and [GitLabPatchSource][app.morphe.engine.patches.GitLabPatchSource] go
+ * through this instead of each hand-rolling request/stream/retry logic.
+ *
+ * Ported (slimmed) from morphe-manager's `HttpService`. The multipart
+ * range-parallel downloader has been intentionally dropped since it avoid the concurrency/range
+ * complexity (Can add this if required). Timeouts + engine live on the injected client (CIO).
+ *
+ * Responsibilities:
+ *  - [request]: GET + ContentNegotiation decode to [T]
+ *  - [getText]: GET raw body text (providers that hand-parse JSON, e.g. GitLab,
+ *    and raw `patches-bundle.json` which is served as text/plain)
+ *  - [head]: HEAD probe (GitLab's cosmetic asset-size resolution)
+ *  - [downloadToFile]: stream a response straight to disk (never buffered
+ *    in memory), via a `.part` file with atomic swap + cleanup on failure
+ *  - retry on transient failures + HTTP 429 (honoring `Retry-After`)
+ */
+class HttpService(
+    @PublishedApi internal val http: HttpClient,
+    @PublishedApi internal val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    @PublishedApi
+    internal val logger: Logger = Logger.getLogger(HttpService::class.java.name)
+
+    /**
+     * GET [url] and decode the body to [T].
+     *
+     * Decoding is done manually (`json.decodeFromString`) off the raw text,
+     * independent of the response's `Content-Type`. So a raw `patches-bundle.json`
+     * served as `text/plain` decodes exactly like an `application/json` API
+     * response, no ContentNegotiation needed. `T == String` returns the raw
+     * body text unparsed (use this for providers that hand-roll JSON, e.g.
+     * GitLab's release list).
+     *
+     * Throws [HttpException] on a non-2xx status after retries are exhausted.
+     */
+    suspend inline fun <reified T> request(
+        url: String,
+        crossinline builder: HttpRequestBuilder.() -> Unit = {},
+    ): T = withRetry("request $url") {
+        val response: HttpResponse = http.get(url) { builder() }
+        response.throwIfError(url)
+        val body = response.bodyAsText()
+        if (T::class == String::class) {
+            @Suppress("UNCHECKED_CAST")
+            body as T
+        } else {
+            json.decodeFromString(body)
+        }
+    }
+
+    /**
+     * HEAD [url] and return the raw [HttpResponse] (headers only). Callers
+     * inspect status/headers themselves. Retries 429. Other statuses are
+     * returned as is (GitLab treats any failure as "unknown size").
+     */
+    suspend fun head(
+        url: String,
+        builder: HttpRequestBuilder.() -> Unit = {},
+    ): HttpResponse = withRetry("head $url") {
+        val response = http.head(url) { builder() }
+        if (response.status == HttpStatusCode.TooManyRequests) {
+            throw TooManyRequestsException(response.retryAfterMillis())
+        }
+        response
+    }
+
+    /**
+     * Download [url] to [saveLocation], streaming straight to disk. The
+     * response body is never stored in memory (Pratham's chess patch is 100MB+ and that would
+     * cause issues. This fixes it. Writes to a `.part` file and atomically swaps on success;
+     * removes the partial file on any failure. Throws on failure after retries.
+     */
+    suspend fun downloadToFile(
+        url: String,
+        saveLocation: File,
+        onProgress: ((bytesRead: Long, contentLength: Long?) -> Unit)? = null,
+        builder: HttpRequestBuilder.() -> Unit = {},
+    ): File {
+        saveLocation.parentFile?.mkdirs()
+        val part = File(saveLocation.parentFile, "${saveLocation.name}.part")
+        try {
+            withRetry("download ${saveLocation.name}") {
+                // append=false: each (re)attempt truncates, so restarting is safe.
+                FileOutputStream(part, false).use { out ->
+                    http.prepareGet(url) { builder() }.execute { response ->
+                        response.throwIfError(url)
+                        val contentLength = response.headers[HttpHeaders.ContentLength]?.toLongOrNull()
+                        withContext(Dispatchers.IO) {
+                            response.bodyAsChannel().toInputStream().use { input ->
+                                copyStreaming(input, out, contentLength, onProgress)
+                            }
+                        }
+                    }
+                }
+            }
+            if (part.length() == 0L) throw HttpException(null, url, "download returned 0 bytes")
+            if (saveLocation.exists()) saveLocation.delete()
+            if (!part.renameTo(saveLocation)) {
+                part.copyTo(saveLocation, overwrite = true); part.delete()
+            }
+            return saveLocation
+        } catch (t: Throwable) {
+            runCatching { if (part.exists()) part.delete() }
+            throw t
+        }
+    }
+
+    /**
+     * Copy [input] → [output] in 64 KB chunks (constant memory), reporting byte
+     * progress. Progress is throttled: at most once per [PROGRESS_MIN_BYTES] or
+     * [PROGRESS_INTERVAL_MS], whichever first, plus a guaranteed final call.
+     */
+    private fun copyStreaming(
+        input: InputStream,
+        output: OutputStream,
+        contentLength: Long?,
+        onProgress: ((bytesRead: Long, contentLength: Long?) -> Unit)?,
+    ) {
+        val buffer = ByteArray(64 * 1024)
+        var total = 0L
+        var lastBytes = 0L
+        var lastAt = 0L
+        while (true) {
+            val read = input.read(buffer)
+            if (read == -1) break
+            output.write(buffer, 0, read)
+            total += read
+            if (onProgress != null) {
+                val now = System.currentTimeMillis()
+                if (total - lastBytes >= PROGRESS_MIN_BYTES || now - lastAt >= PROGRESS_INTERVAL_MS) {
+                    lastBytes = total
+                    lastAt = now
+                    onProgress(total, contentLength)
+                }
+            }
+        }
+        onProgress?.invoke(total, contentLength)
+    }
+
+    /**
+     * Single retry layer: retries [block] on transient exceptions (connection
+     * reset, DNS, timeout, 5xx) and HTTP 429 (honoring `Retry-After`), with
+     * exponential backoff. Permanent 4xx (404/401/403…) surface immediately;
+     * cancellation is never caught.
+     */
+    @PublishedApi
+    internal suspend fun <T> withRetry(operation: String, block: suspend () -> T): T {
+        var attempt = 0
+        var delayMs = INITIAL_RETRY_DELAY_MS
+        while (true) {
+            attempt++
+            try {
+                return block()
+            } catch (t: CancellationException) {
+                throw t
+            } catch (t: TooManyRequestsException) {
+                if (attempt >= MAX_RETRY_ATTEMPTS) {
+                    throw HttpException(HttpStatusCode.TooManyRequests, operation, cause = t)
+                }
+                val wait = (t.retryAfterMillis ?: delayMs).coerceAtMost(MAX_RETRY_DELAY_MS)
+                logger.warning("$operation hit 429 (attempt $attempt/$MAX_RETRY_ATTEMPTS), waiting ${wait}ms")
+                delay(wait)
+                delayMs = (delayMs * 2).coerceAtMost(MAX_RETRY_DELAY_MS)
+            } catch (t: HttpException) {
+                if (!t.isRetryable || attempt >= MAX_RETRY_ATTEMPTS) throw t
+                logger.warning("$operation attempt $attempt: retryable HTTP error: ${t.message}")
+                delay(delayMs)
+                delayMs = (delayMs * 2).coerceAtMost(MAX_RETRY_DELAY_MS)
+            } catch (t: Exception) {
+                if (attempt >= MAX_RETRY_ATTEMPTS) throw t
+                logger.warning("$operation attempt $attempt failed: ${t::class.simpleName}: ${t.message}")
+                delay(delayMs)
+                delayMs = (delayMs * 2).coerceAtMost(MAX_RETRY_DELAY_MS)
+            }
+        }
+    }
+
+    /** Throw on 429 (→ retry with Retry-After) or any other non-2xx (→ [HttpException]). */
+    @PublishedApi
+    internal suspend fun HttpResponse.throwIfError(url: String) {
+        if (status == HttpStatusCode.TooManyRequests) throw TooManyRequestsException(retryAfterMillis())
+        if (!status.isSuccess()) {
+            val body = runCatching { bodyAsText() }.getOrNull()
+            throw HttpException(status, url, body)
+        }
+    }
+
+    /** `Retry-After` (seconds) → millis, or null when absent/unparseable. */
+    @PublishedApi
+    internal fun HttpResponse.retryAfterMillis(): Long? =
+        headers[HttpHeaders.RetryAfter]?.toLongOrNull()?.coerceAtLeast(0)?.times(1000)
+
+    /**
+     * Preserves the HTTP status (when known), the request URL, and a short
+     * body snippet so callers get real diagnostics. [isRetryable] drives
+     * [withRetry]: timeouts (null status), 5xx, and 429 are transient. Other 4xx are not.
+     */
+    class HttpException(
+        val status: HttpStatusCode?,
+        val requestUrl: String? = null,
+        val responseBodySnippet: String? = null,
+        cause: Throwable? = null,
+    ) : Exception(
+        buildString {
+            append("HTTP request failed")
+            if (status != null) append(" with status $status")
+            if (requestUrl != null) append(" for $requestUrl")
+            if (responseBodySnippet != null) append(": ${responseBodySnippet.take(200)}")
+        },
+        cause,
+    ) {
+        val isRetryable: Boolean
+            get() = status == null || status == HttpStatusCode.TooManyRequests || status.value >= 500
+    }
+
+    class TooManyRequestsException(val retryAfterMillis: Long?) :
+        Exception("HTTP 429 Too Many Requests")
+
+    companion object {
+        private const val MAX_RETRY_ATTEMPTS = 3
+        private const val INITIAL_RETRY_DELAY_MS = 1_000L
+        private const val MAX_RETRY_DELAY_MS = 30_000L
+
+        /** Min bytes between download-progress callbacks. */
+        private const val PROGRESS_MIN_BYTES = 64 * 1024L
+
+        /** Min ms between download-progress callbacks. */
+        private const val PROGRESS_INTERVAL_MS = 200L
+    }
+}

--- a/src/main/kotlin/app/morphe/engine/patches/GitHubPatchSource.kt
+++ b/src/main/kotlin/app/morphe/engine/patches/GitHubPatchSource.kt
@@ -5,30 +5,27 @@
 
 package app.morphe.engine.patches
 
+import app.morphe.engine.model.PatchesBundle
 import app.morphe.engine.model.Release
 import app.morphe.engine.model.ReleaseAsset
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
+import app.morphe.engine.network.HttpService
 import io.ktor.client.request.headers
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpHeaders
-import io.ktor.http.isSuccess
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.logging.Logger
 
 /**
- * GitHub provider. Hits api.github.com/repos/{owner}/{repo}/releases.
+ * GitHub provider. Hits api.github.com/repos/{owner}/{repo}/releases for the
+ * full version list, and the raw `patches-bundle.json` for the latest.
  *
- * GitHub's release JSON matches our [Release] model directly (the SerialName
- * annotations align with GitHub's field names), so deserialization is a
- * straight `response.body()` via Ktor content negotiation.
+ * All networking (requests, streaming download, retry/429) is delegated to
+ * the shared [HttpService]. This class only owns GitHub's URL shapes and the
+ * fact that its release JSON maps straight onto our [Release] model.
  */
 class GitHubPatchSource(
-    private val httpClient: HttpClient,
+    private val http: HttpService,
     override val repoPath: String,
 ) : RemotePatchSource {
 
@@ -40,18 +37,12 @@ class GitHubPatchSource(
     override suspend fun listReleases(): Result<List<Release>> = withContext(Dispatchers.IO) {
         try {
             logger.info("GitHub: fetching releases from $releasesEndpoint")
-            val response: HttpResponse = httpClient.get(releasesEndpoint) {
+            val releases: List<Release> = http.request(releasesEndpoint) {
                 headers {
                     append(HttpHeaders.Accept, "application/vnd.github+json")
                     append("X-GitHub-Api-Version", "2022-11-28")
                 }
             }
-            if (!response.status.isSuccess()) {
-                return@withContext Result.failure(
-                    Exception("GitHub releases fetch failed: HTTP ${response.status}")
-                )
-            }
-            val releases: List<Release> = response.body()
             logger.info("GitHub: fetched ${releases.size} releases from $repoPath")
             Result.success(releases)
         } catch (e: Exception) {
@@ -60,40 +51,40 @@ class GitHubPatchSource(
         }
     }
 
+    override suspend fun fetchLatestFromManifest(prerelease: Boolean): Result<Release> = withContext(Dispatchers.IO) {
+        try {
+            val branch = if (prerelease) "dev" else "main"
+            val url = "$RAW_BASE/$repoPath/$branch/patches-bundle.json"
+            logger.info("GitHub: fetching patches-bundle.json from $url")
+            val bundle: PatchesBundle = http.request(url)
+            logger.info("GitHub: bundle ($branch) → v${bundle.version} @ ${bundle.downloadUrl}")
+            Result.success(bundle.toRelease(prerelease))
+        } catch (e: Exception) {
+            logger.info("GitHub: no usable patches-bundle.json for $repoPath (${e.message}). Falling back to releases API")
+            Result.failure(e)
+        }
+    }
+
     override suspend fun downloadAsset(
         asset: ReleaseAsset,
         targetFile: File,
+        onProgress: ((bytesRead: Long, contentLength: Long?) -> Unit)?,
     ): Result<File> = withContext(Dispatchers.IO) {
         try {
             logger.info("GitHub: downloading ${asset.name} from ${asset.downloadUrl}")
-            val response: HttpResponse = httpClient.get(asset.downloadUrl) {
-                headers {
-                    append(HttpHeaders.Accept, "application/octet-stream")
-                }
+            val file = http.downloadToFile(asset.downloadUrl, targetFile, onProgress) {
+                headers { append(HttpHeaders.Accept, "application/octet-stream") }
             }
-            if (!response.status.isSuccess()) {
-                return@withContext Result.failure(
-                    Exception("Download failed: HTTP ${response.status} from ${asset.downloadUrl}")
-                )
-            }
-            val bytes = response.readRawBytes()
-            if (bytes.isEmpty()) {
-                return@withContext Result.failure(
-                    Exception("Download returned 0 bytes from ${asset.downloadUrl}")
-                )
-            }
-            targetFile.parentFile?.mkdirs()
-            targetFile.writeBytes(bytes)
-            logger.info("GitHub: wrote ${bytes.size} bytes to ${targetFile.absolutePath}")
-            Result.success(targetFile)
+            logger.info("GitHub: wrote ${file.length()} bytes to ${file.absolutePath}")
+            Result.success(file)
         } catch (e: Exception) {
-            // Don't leave a partial file behind
-            if (targetFile.exists() && targetFile.length() == 0L) targetFile.delete()
+            logger.warning("GitHub download failed (${e::class.simpleName}): ${e.message}")
             Result.failure(e)
         }
     }
 
     companion object {
         private const val API_BASE = "https://api.github.com"
+        private const val RAW_BASE = "https://raw.githubusercontent.com"
     }
 }

--- a/src/main/kotlin/app/morphe/engine/patches/GitLabPatchSource.kt
+++ b/src/main/kotlin/app/morphe/engine/patches/GitLabPatchSource.kt
@@ -5,15 +5,12 @@
 
 package app.morphe.engine.patches
 
+import app.morphe.engine.model.PatchesBundle
 import app.morphe.engine.model.Release
 import app.morphe.engine.model.ReleaseAsset
-import io.ktor.client.HttpClient
-import io.ktor.client.request.get
-import io.ktor.client.request.head
+import app.morphe.engine.network.HttpService
 import io.ktor.client.request.headers
 import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
-import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.Dispatchers
@@ -32,21 +29,19 @@ import java.net.URLEncoder
 import java.util.logging.Logger
 
 /**
- * GitLab provider. Hits gitlab.com/api/v4/projects/{owner%2Frepo}/releases.
+ * GitLab provider. Hits gitlab.com/api/v4/projects/{owner%2Frepo}/releases for
+ * the full version list, and the raw `patches-bundle.json` for the latest.
  *
- * GitLab's release JSON shape differs from GitHub's in several ways that
- * require normalization rather than direct deserialization:
- *   - Assets live under `assets.links[]`, not `assets[]`
- *   - Each asset link uses `direct_asset_url` (or fallback `url`), not
- *     `browser_download_url`
- *   - No `prerelease` flag — dev detection falls back to the tag-name
- *     heuristic in [Release.isDevRelease]
- *   - No size or content_type in the release payload — we resolve sizes
- *     via parallel HEAD requests against the .mpp assets we care about,
- *     so the UI can show real megabytes
+ * All networking (requests, streaming download, retry/429) is delegated to the
+ * shared [HttpService]. This class owns GitLab's URL shapes and the JSON
+ * normalization its release payload needs:
+ *  - Assets live under `assets.links[]`, not `assets[]`
+ *  - Each asset link uses `direct_asset_url` (or fallback `url`), not `browser_download_url`
+ *  - No `prerelease` flag in GitLab. Dev detection falls back to the tag-name heuristic in [Release.isDevRelease]
+ *  - No size or content_type in the release payload. We resolve sizes via parallel HEAD requests against the .mpp assets we care about
  */
 class GitLabPatchSource(
-    private val httpClient: HttpClient,
+    private val http: HttpService,
     override val repoPath: String,
 ) : RemotePatchSource {
 
@@ -63,17 +58,9 @@ class GitLabPatchSource(
     override suspend fun listReleases(): Result<List<Release>> = withContext(Dispatchers.IO) {
         try {
             logger.info("GitLab: fetching releases from $releasesEndpoint")
-            val response: HttpResponse = httpClient.get(releasesEndpoint) {
-                headers {
-                    append(HttpHeaders.Accept, "application/json")
-                }
+            val raw = http.request<String>(releasesEndpoint) {
+                headers { append(HttpHeaders.Accept, "application/json") }
             }
-            if (!response.status.isSuccess()) {
-                return@withContext Result.failure(
-                    Exception("GitLab releases fetch failed: HTTP ${response.status}")
-                )
-            }
-            val raw = response.bodyAsText()
             val releases = parseReleases(raw)
             logger.info("GitLab: fetched ${releases.size} releases from $repoPath")
             Result.success(releases)
@@ -83,34 +70,34 @@ class GitLabPatchSource(
         }
     }
 
+    override suspend fun fetchLatestFromManifest(prerelease: Boolean): Result<Release> = withContext(Dispatchers.IO) {
+        try {
+            val branch = if (prerelease) "dev" else "main"
+            val url = "$RAW_BASE/$repoPath/-/raw/$branch/patches-bundle.json"
+            logger.info("GitLab: fetching patches-bundle.json from $url")
+            val bundle: PatchesBundle = http.request(url)
+            logger.info("GitLab: bundle ($branch) → v${bundle.version} @ ${bundle.downloadUrl}")
+            Result.success(bundle.toRelease(prerelease))
+        } catch (e: Exception) {
+            logger.info("GitLab: no usable patches-bundle.json for $repoPath (${e.message}); will fall back to releases API")
+            Result.failure(e)
+        }
+    }
+
     override suspend fun downloadAsset(
         asset: ReleaseAsset,
         targetFile: File,
+        onProgress: ((bytesRead: Long, contentLength: Long?) -> Unit)?,
     ): Result<File> = withContext(Dispatchers.IO) {
         try {
             logger.info("GitLab: downloading ${asset.name} from ${asset.downloadUrl}")
-            val response: HttpResponse = httpClient.get(asset.downloadUrl) {
-                headers {
-                    append(HttpHeaders.Accept, "application/octet-stream")
-                }
+            val file = http.downloadToFile(asset.downloadUrl, targetFile, onProgress) {
+                headers { append(HttpHeaders.Accept, "application/octet-stream") }
             }
-            if (!response.status.isSuccess()) {
-                return@withContext Result.failure(
-                    Exception("Download failed: HTTP ${response.status} from ${asset.downloadUrl}")
-                )
-            }
-            val bytes = response.readRawBytes()
-            if (bytes.isEmpty()) {
-                return@withContext Result.failure(
-                    Exception("Download returned 0 bytes from ${asset.downloadUrl}")
-                )
-            }
-            targetFile.parentFile?.mkdirs()
-            targetFile.writeBytes(bytes)
-            logger.info("GitLab: wrote ${bytes.size} bytes to ${targetFile.absolutePath}")
-            Result.success(targetFile)
+            logger.info("GitLab: wrote ${file.length()} bytes to ${file.absolutePath}")
+            Result.success(file)
         } catch (e: Exception) {
-            if (targetFile.exists() && targetFile.length() == 0L) targetFile.delete()
+            logger.warning("GitLab download failed (${e::class.simpleName}): ${e.message}")
             Result.failure(e)
         }
     }
@@ -121,8 +108,7 @@ class GitLabPatchSource(
         val root = Json.parseToJsonElement(rawJson)
         val array = (root as? JsonArray) ?: return emptyList()
 
-        // Pass 1: collect tag/name/etc + (assetName, downloadUrl) pairs, sizes
-        // still unknown.
+        // Collect tag/name/etc + (assetName, downloadUrl) pairs, sizes still unknown.
         data class RawRelease(
             val tagName: String,
             val name: String?,
@@ -149,10 +135,9 @@ class GitLabPatchSource(
             RawRelease(tagName, name, publishedAt, description, assetPairs)
         }
 
-        // Pass 1.5: resolve sizes for .mpp assets via parallel HEAD requests.
-        // GitLab's 2000 req/hr unauth limit means even ~50 HEADs per fetch
-        // is comfortably within budget; running them in parallel keeps total
-        // latency at one round-trip.
+        // Resolve sizes for .mpp assets via parallel HEAD requests.
+        // GitLab's 2000 req/hr unauth limit means even ~50 HEADs per fetch is comfortably within budget.
+        // Running them in parallel keeps total latency at one round-trip.
         val mppUrls: Set<String> = rawReleases
             .flatMap { it.assets }
             .filter { it.first.endsWith(".mpp", ignoreCase = true) }
@@ -169,7 +154,7 @@ class GitLabPatchSource(
             }
         }
 
-        // Pass 2: build the model with resolved sizes spliced in.
+        // Build the model with resolved sizes spliced in.
         return rawReleases.map { raw ->
             val releaseAssets = raw.assets.map { (assetName, downloadUrl) ->
                 ReleaseAsset(
@@ -181,8 +166,7 @@ class GitLabPatchSource(
             Release(
                 tagName = raw.tagName,
                 name = raw.name,
-                // GitLab has no prerelease flag — dev detection falls back to
-                // tag-name patterns inside Release.isDevRelease().
+                // GitLab has no prerelease flag. Dev detection falls back to tag-name patterns inside Release.isDevRelease().
                 isPrerelease = false,
                 publishedAt = raw.publishedAt,
                 assets = releaseAssets,
@@ -192,12 +176,11 @@ class GitLabPatchSource(
     }
 
     /**
-     * HEAD a URL and read Content-Length. Returns 0 on any failure — size is
-     * cosmetic, never blocks the release listing.
+     * HEAD a URL and read Content-Length. Returns 0 on any failure. Size never blocks the release listing.
      */
     private suspend fun resolveContentLength(url: String): Long {
         return try {
-            val response: HttpResponse = httpClient.head(url)
+            val response: HttpResponse = http.head(url)
             if (!response.status.isSuccess()) {
                 logger.fine("HEAD $url returned ${response.status}")
                 return 0L
@@ -211,5 +194,6 @@ class GitLabPatchSource(
 
     companion object {
         private const val API_BASE = "https://gitlab.com/api/v4"
+        private const val RAW_BASE = "https://gitlab.com"
     }
 }

--- a/src/main/kotlin/app/morphe/engine/patches/RemotePatchSource.kt
+++ b/src/main/kotlin/app/morphe/engine/patches/RemotePatchSource.kt
@@ -44,19 +44,35 @@ interface RemotePatchSource {
     suspend fun listReleases(): Result<List<Release>>
 
     /**
+     * Resolve the latest release from the repo's `patches-bundle.json` via the **raw
+     * CDN**, avoiding the rate-limited releases API. [prerelease] selects the `dev`
+     * branch (vs `main` for stable).
+     *
+     * Returns a failed [Result] when the source publishes no manifest (or it can't be
+     * fetched/parsed). Callers should fall back to [listReleases]. Never throws.
+     */
+    suspend fun fetchLatestFromManifest(prerelease: Boolean): Result<Release>
+
+    /**
      * Download [asset] to [targetFile]. Replaces any existing file at the
      * target path. Returns the file on success.
      *
      * Implementations are responsible for:
-     *   - Following any provider-specific redirects (GitLab's `direct_asset_url`)
-     *   - Sending appropriate Accept / auth headers
-     *   - Failing if the response body is empty (zero-byte downloads are
-     *     never valid patch files)
+     *  - Following any provider-specific redirects (GitLab's `direct_asset_url`)
+     *  - Sending appropriate Accept / auth headers
+     *  - Failing if the response body is empty (zero-byte downloads are never valid patch files)
      *
-     * Implementations are NOT responsible for cache-hit checks — the caller
+     * Implementations are NOT responsible for cache-hit checks. The caller
      * should look at [targetFile] before calling this if it wants caching.
+     *
+     * [onProgress] (optional) reports `(bytesRead, contentLength?)` as the body
+     * streams to disk; `contentLength` is null when the server omits it.
      */
-    suspend fun downloadAsset(asset: ReleaseAsset, targetFile: File): Result<File>
+    suspend fun downloadAsset(
+        asset: ReleaseAsset,
+        targetFile: File,
+        onProgress: ((bytesRead: Long, contentLength: Long?) -> Unit)? = null,
+    ): Result<File>
 }
 
 /**

--- a/src/main/kotlin/app/morphe/engine/patches/RemotePatchSourceFactory.kt
+++ b/src/main/kotlin/app/morphe/engine/patches/RemotePatchSourceFactory.kt
@@ -5,6 +5,7 @@
 
 package app.morphe.engine.patches
 
+import app.morphe.engine.network.HttpService
 import io.ktor.client.HttpClient
 
 /**
@@ -103,9 +104,15 @@ object RemotePatchSourceFactory {
                 PatchProvider.GITLAB -> "https://gitlab.com/$repoPath"
             }
 
-        fun instantiate(httpClient: HttpClient): RemotePatchSource = when (provider) {
-            PatchProvider.GITHUB -> GitHubPatchSource(httpClient, repoPath)
-            PatchProvider.GITLAB -> GitLabPatchSource(httpClient, repoPath)
+        fun instantiate(httpClient: HttpClient): RemotePatchSource {
+            // Wrap the shared client in the centralized service so both sources
+            // get identical request/stream/retry behavior. Call sites still pass
+            // an HttpClient, so nothing downstream changes.
+            val service = HttpService(httpClient)
+            return when (provider) {
+                PatchProvider.GITHUB -> GitHubPatchSource(service, repoPath)
+                PatchProvider.GITLAB -> GitLabPatchSource(service, repoPath)
+            }
         }
     }
 }

--- a/src/main/kotlin/app/morphe/gui/data/repository/PatchRepository.kt
+++ b/src/main/kotlin/app/morphe/gui/data/repository/PatchRepository.kt
@@ -103,10 +103,26 @@ class PatchRepository(
         fetchReleases().map { releases -> releases.filter { it.isDevRelease() } }
 
     suspend fun getLatestStableRelease(): Result<Release?> =
-        fetchStableReleases().map { it.firstOrNull() }
+        latestFromManifestOrApi(prerelease = false)
 
     suspend fun getLatestDevRelease(): Result<Release?> =
-        fetchDevReleases().map { it.firstOrNull() }
+        latestFromManifestOrApi(prerelease = true)
+
+    /**
+     * Resolve the latest release for a channel via the repo's `patches-bundle.json`
+     * (raw CDN, no API rate limit); fall back to the releases API only when the source
+     * publishes no manifest. This is the common path, so it keeps the tight 60/hr GitHub
+     * API budget for the rarer "list older versions" case.
+     */
+    private suspend fun latestFromManifestOrApi(prerelease: Boolean): Result<Release?> =
+        withContext(Dispatchers.IO) {
+            remoteSource.fetchLatestFromManifest(prerelease).getOrNull()?.let {
+                Logger.info("Latest ${if (prerelease) "dev" else "stable"} via patches-bundle.json: ${it.tagName}")
+                return@withContext Result.success(it)
+            }
+            if (prerelease) fetchDevReleases().map { it.firstOrNull() }
+            else fetchStableReleases().map { it.firstOrNull() }
+        }
 
     /** Find the patch .mpp asset in a release. */
     fun findPatchAsset(release: Release): ReleaseAsset? = release.findPatchAsset()
@@ -146,8 +162,15 @@ class PatchRepository(
             return@withContext Result.success(targetFile)
         }
 
-        // Delegate the actual network IO to the engine source.
-        val result = remoteSource.downloadAsset(asset, targetFile)
+        // Delegate the actual network IO to the engine source, translating byte
+        // progress into a 0..1 fraction for the UI. When the server omits
+        // Content-Length we can't compute a fraction, so the bar stays put until
+        // completion — GitHub/GitLab CDN downloads do send it, so this is rare.
+        val result = remoteSource.downloadAsset(asset, targetFile) { bytesRead, contentLength ->
+            if (contentLength != null && contentLength > 0L) {
+                onProgress((bytesRead.toFloat() / contentLength).coerceIn(0f, 1f))
+            }
+        }
         if (result.isSuccess) onProgress(1f)
         result
     }

--- a/src/main/kotlin/app/morphe/gui/di/AppModule.kt
+++ b/src/main/kotlin/app/morphe/gui/di/AppModule.kt
@@ -13,6 +13,7 @@ import app.morphe.engine.PatchedAppStore
 import app.morphe.gui.util.PatchService
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.serialization.kotlinx.json.*
@@ -52,8 +53,17 @@ val appModule = module {
                     }
                 }
             }
+            // Socket-based (idle) timeouts, not a wall-clock cap. A large but flowing
+            // patch download is never killed just for being big.
+            // requestTimeoutMillis is left unset (infinite).
+            install(HttpTimeout) {
+                connectTimeoutMillis = 30_000
+                socketTimeoutMillis = 60_000
+            }
+            // Retry/429 handling lives in HttpService (single layer). Not a client plugin, to avoid compounding retries.
             engine {
-                requestTimeout = 60_000
+                // Disable the engine-level total-call cap; the timeouts above govern.
+                requestTimeout = 0
             }
         }
     }

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionViewModel.kt
@@ -692,21 +692,23 @@ class PatchSelectionViewModel(
 
         Logger.info("Looking for patches version: ${expectedVersion ?: "latest"}")
 
-        val releasesResult = patchRepository.fetchReleases()
-        if (releasesResult.isFailure) {
-            return Result.failure(
-                releasesResult.exceptionOrNull() ?: Exception("Failed to fetch releases")
-            )
-        }
-        val releases = releasesResult.getOrNull() ?: emptyList()
-        if (releases.isEmpty()) return Result.failure(Exception("No releases found"))
-
         val targetRelease = if (expectedVersion != null) {
+            // A specific version is expected (repatch/update) → the full release list
+            // (API) is the only way to locate that exact tag.
+            val releasesResult = patchRepository.fetchReleases()
+            if (releasesResult.isFailure) {
+                return Result.failure(releasesResult.exceptionOrNull() ?: Exception("Failed to fetch releases"))
+            }
+            val releases = releasesResult.getOrNull() ?: emptyList()
+            if (releases.isEmpty()) return Result.failure(Exception("No releases found"))
             releases.find { it.tagName.contains(expectedVersion) }
                 ?: releases.firstOrNull { !it.isDevRelease() }
+                ?: return Result.failure(Exception("No suitable release found"))
         } else {
-            releases.firstOrNull { !it.isDevRelease() }
-        } ?: return Result.failure(Exception("No suitable release found"))
+            // Just need the latest stable → resolve via the raw manifest (no API call).
+            patchRepository.getLatestStableRelease().getOrNull()
+                ?: return Result.failure(Exception("No suitable release found"))
+        }
 
         Logger.info("Downloading patches from release: ${targetRelease.tagName}")
         return patchRepository.downloadPatches(targetRelease)

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchesScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchesScreen.kt
@@ -853,8 +853,8 @@ private fun BottomActionBar(
                     .fillMaxWidth()
                     .height(3.dp)
                     .clip(RoundedCornerShape(1.dp)),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                trackColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.1f)
+                color = accents.primary,
+                trackColor = accents.primary.copy(alpha = 0.15f)
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(

--- a/src/main/kotlin/app/morphe/gui/util/EnabledSourcesLoader.kt
+++ b/src/main/kotlin/app/morphe/gui/util/EnabledSourcesLoader.kt
@@ -7,6 +7,7 @@ package app.morphe.gui.util
 
 import app.morphe.engine.MultiSourceLoader
 import app.morphe.gui.data.model.FollowMode
+import app.morphe.engine.model.Release
 import app.morphe.gui.data.model.PatchSource
 import app.morphe.gui.data.model.PatchSourceType
 import app.morphe.gui.data.model.SourceVersionPref
@@ -177,42 +178,35 @@ object EnabledSourcesLoader {
             return ResolvedSource(source = source, error = "No repository configured for source")
         }
 
-        val releasesResult = repo.fetchReleases()
-        val releases = releasesResult.getOrNull()
+        // Resolve the target release WITHOUT the releases API where possible:
+        //  - FOLLOW_STABLE / default / FOLLOW_DEV → latest via the raw patches-bundle.json.
+        //    getLatest*Release is manifest-first (it only touches the API if the source
+        //    ships no manifest), so following sources cost 0 API calls on startup.
+        //  - PINNED → needs the full release list (API) to locate the exact old tag.
+        val release: Release?
+        val latestStableTag: String?
+        val latestDevTag: String?
 
-        if (releases.isNullOrEmpty()) {
-            // Offline fallback: scan source's cache dir for any .mpp/.jar file
-            val cached = findCachedPatchFile(repo)
-            if (cached != null) {
-                return ResolvedSource(
-                    source = source,
-                    patchFile = cached,
-                    resolvedVersion = versionFromFilename(cached),
-                    isOffline = true,
-                )
-            }
-            val errMsg = releasesResult.exceptionOrNull()?.message ?: "Could not fetch releases"
-            return ResolvedSource(source = source, error = errMsg)
+        if (pref?.mode == FollowMode.PINNED) {
+            val releases = repo.fetchReleases().getOrNull()
+            if (releases.isNullOrEmpty()) return offlineOrError(source, repo)
+            val latestStable = releases.firstOrNull { !it.isDevRelease() }
+            release = releases.find { it.tagName == pref.pinnedTag } ?: latestStable ?: releases.firstOrNull()
+            latestStableTag = latestStable?.tagName
+            latestDevTag = releases.firstOrNull { it.isDevRelease() }?.tagName
+        } else {
+            val stable = repo.getLatestStableRelease().getOrNull()
+            val dev = repo.getLatestDevRelease().getOrNull()
+            release = if (pref?.mode == FollowMode.FOLLOW_DEV) (dev ?: stable) else (stable ?: dev)
+            latestStableTag = stable?.tagName
+            latestDevTag = dev?.tagName
         }
 
-        // Resolve which release to load from this source's version preference:
-        //  - PINNED        → the exact tag (fall back to latest stable if it's gone)
-        //  - FOLLOW_DEV    → newest release overall, pre-releases included
-        //  - FOLLOW_STABLE → newest stable (also the default when there's no pref)
-        // The release list is newest-first, so firstOrNull() is the newest overall.
-        val latestStable = releases.firstOrNull { !it.isDevRelease() }
-        val latestOverall = releases.firstOrNull()
-        val release = when (pref?.mode) {
-            FollowMode.PINNED ->
-                releases.find { it.tagName == pref.pinnedTag } ?: latestStable ?: latestOverall
-            FollowMode.FOLLOW_DEV -> latestOverall ?: latestStable
-            FollowMode.FOLLOW_STABLE, null -> latestStable ?: latestOverall
-        } ?: return ResolvedSource(source = source, error = "No releases found")
+        // Manifest + API both unavailable (e.g. offline) → fall back to a cached file.
+        if (release == null) return offlineOrError(source, repo)
 
-        // Classify where the resolved release actually sits (for the LED + badge),
-        // independent of which track it's following.
-        val latestStableTag = latestStable?.tagName
-        val latestDevTag = releases.firstOrNull { it.isDevRelease() }?.tagName
+        // Classify where the resolved release sits (for the LED + badge), independent
+        // of which track it's following.
         val channel = when {
             release.isDevRelease() && release.tagName == latestDevTag -> Channel.DEV_LATEST
             release.isDevRelease() -> Channel.DEV_OLDER
@@ -236,6 +230,21 @@ object EnabledSourcesLoader {
             isOffline = false,
             channel = channel,
         )
+    }
+
+    /** Offline / no-releases fallback: use the newest cached .mpp/.jar for this source. */
+    private fun offlineOrError(source: PatchSource, repo: PatchRepository): ResolvedSource {
+        val cached = findCachedPatchFile(repo)
+        return if (cached != null) {
+            ResolvedSource(
+                source = source,
+                patchFile = cached,
+                resolvedVersion = versionFromFilename(cached),
+                isOffline = true,
+            )
+        } else {
+            ResolvedSource(source = source, error = "Could not fetch releases")
+        }
     }
 
     private fun findCachedPatchFile(repo: PatchRepository): File? {


### PR DESCRIPTION
- Switched from github/ gitlab api links to raw link which gives a much generous amount of calls before rate limiting. The latest stable/dev versions are now resolve from the repo's raw patches-bundle.json. (API is still present as fallback for fetching patches in case raw fails and also for getting older patches if a user opens the patch version selection screen.)
- Patch downloads now stream straight to disk (as .part file) instead of buffering the whole file in memory. This fixes large files from failing.
- Implemented a slimmed down version of the manager's HttpService. This unifies a lot of stuff that the GitHubPatchSource and GitLabPatchSource used to do, hence this does a decent bit of unification too.
- Added progress for patch download (Minor UI change to make sure the users aren't kept in the dark. Won't notice it usually, but can be seen on larger patches)