### PR TITLE
feat: add built-in self-updater for morphe-desktop

### DIFF
--- a/src/main/kotlin/app/morphe/desktop/command/MainCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/MainCommand.kt
@@ -46,6 +46,7 @@ private object CLIVersionProvider : IVersionProvider {
         ListCompatibleVersions::class,
         OptionsCommand::class,
         UtilityCommand::class,
+        UpdateCommand::class,
     ]
 )
 @VisibleForTesting

--- a/src/main/kotlin/app/morphe/desktop/command/UpdateCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/UpdateCommand.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.desktop.command
+
+import app.morphe.engine.ReleaseChannel
+import app.morphe.engine.network.HttpService
+import app.morphe.engine.update.SelfUpdateChecker
+import app.morphe.engine.update.UpdateDownloadManager
+import app.morphe.engine.update.UpdateInstaller
+import app.morphe.engine.update.UpdateReleaseInfo
+import app.morphe.engine.update.UpdateVerifier
+import app.morphe.engine.update.VerificationResult
+import kotlinx.coroutines.runBlocking
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import java.io.File
+import java.util.concurrent.Callable
+import java.util.logging.Logger
+
+/**
+ * `morphe-cli update <check|status|download|install>`.
+ *
+ * Deliberately thin — every subcommand delegates straight to the same
+ * [app.morphe.engine.update] classes [SelfUpdateDialog][app.morphe.gui.ui.components.SelfUpdateDialog]
+ * uses, so the CLI and GUI can never drift on what "an update" means, how
+ * it's verified, or how it's installed. `status` reuses `check`'s resolution
+ * logic rather than maintaining separate persisted state — there's nothing
+ * a fresh check costs here that a cached status file would meaningfully
+ * save, and a second source of truth is one more way for CLI and GUI to
+ * disagree.
+ */
+@Command(
+    name = "update",
+    description = ["Check for, download, and install Morphe Desktop updates."],
+    subcommands = [
+        UpdateCommand.CheckCommand::class,
+        UpdateCommand.StatusCommand::class,
+        UpdateCommand.DownloadCommand::class,
+        UpdateCommand.InstallCommand::class,
+    ],
+)
+internal object UpdateCommand {
+
+    private const val EXIT_OK = 0
+    private const val EXIT_ERROR = 1
+    private const val EXIT_UPDATE_AVAILABLE = 2
+
+    private val logger = Logger.getLogger(UpdateCommand::class.java.name)
+
+    /** Shared `--channel` option + resolution logic for all four subcommands. */
+    internal abstract class ChannelAwareCommand : Callable<Int> {
+        @Option(names = ["--channel"], description = ["stable or dev. Defaults to stable."])
+        var channel: String = "stable"
+
+        protected fun resolveChannel(): ReleaseChannel? = when (channel.lowercase()) {
+            "stable" -> ReleaseChannel.STABLE
+            "dev" -> ReleaseChannel.DEV
+            else -> null
+        }
+
+        protected fun http(): HttpService = HttpService(CliHttpClient.instance)
+
+        /** Runs the check, printing a consistent error/no-op message on every non-happy path. */
+        protected fun checkOrNull(): UpdateReleaseInfo? = runBlocking {
+            val resolvedChannel = resolveChannel() ?: run {
+                logger.severe("Unknown channel '$channel' — expected 'stable' or 'dev'.")
+                return@runBlocking null
+            }
+            SelfUpdateChecker.fetchLatest(http(), resolvedChannel)
+                .onFailure { logger.severe("Update check failed: ${it.message}") }
+                .getOrNull()
+        }
+    }
+
+    @Command(name = "check", description = ["Check whether a newer version is available."])
+    internal object CheckCommand : ChannelAwareCommand() {
+        override fun call(): Int {
+            val info = checkOrNull()
+            return if (info == null) {
+                logger.info("Morphe Desktop is up to date.")
+                EXIT_OK
+            } else {
+                logger.info(
+                    "Update available: v${info.currentVersion} -> v${info.latestVersion} " +
+                        "(${info.channel.name.lowercase()}, ${info.asset.getFormattedSize()})"
+                )
+                EXIT_UPDATE_AVAILABLE
+            }
+        }
+    }
+
+    @Command(name = "status", description = ["Show the current version, channel, and update availability."])
+    internal object StatusCommand : ChannelAwareCommand() {
+        override fun call(): Int {
+            val current = app.morphe.engine.UpdateChecker.currentVersion() ?: "unknown"
+            val info = checkOrNull()
+            logger.info(
+                buildString {
+                    appendLine("Current version : v$current")
+                    appendLine("Channel          : ${channel.lowercase()}")
+                    append(
+                        "Update available : " +
+                            if (info != null) "yes (v${info.latestVersion})" else "no"
+                    )
+                }
+            )
+            return EXIT_OK
+        }
+    }
+
+    @Command(name = "download", description = ["Download (and verify) the latest update without installing it."])
+    internal object DownloadCommand : ChannelAwareCommand() {
+        override fun call(): Int {
+            val info = checkOrNull() ?: run {
+                logger.info("No update to download.")
+                return EXIT_OK
+            }
+            val downloadManager = UpdateDownloadManager(http())
+            val file = runBlocking {
+                var lastPercent = -1
+                downloadManager.download(info) { progress ->
+                    val percent = progress.fraction?.let { (it * 100).toInt() } ?: return@download
+                    if (percent != lastPercent) {
+                        lastPercent = percent
+                        print("\rDownloading v${info.latestVersion}: $percent%")
+                        System.out.flush()
+                    }
+                }
+            }
+            println()
+
+            return when (val result = UpdateVerifier().verify(file, info.asset)) {
+                is VerificationResult.Success -> {
+                    logger.info("Downloaded and verified: ${file.absolutePath} (sha256=${result.sha256})")
+                    EXIT_OK
+                }
+                else -> {
+                    file.delete()
+                    logger.severe("Verification failed: $result")
+                    EXIT_ERROR
+                }
+            }
+        }
+    }
+
+    @Command(name = "install", description = ["Download, verify, and install the latest update, restarting Morphe."])
+    internal object InstallCommand : ChannelAwareCommand() {
+        override fun call(): Int {
+            val info = checkOrNull() ?: run {
+                logger.info("Already up to date — nothing to install.")
+                return EXIT_OK
+            }
+
+            val downloadManager = UpdateDownloadManager(http())
+            val staged: File = downloadManager.stagedFileIfComplete(info) ?: runBlocking {
+                logger.info("Downloading v${info.latestVersion}…")
+                downloadManager.download(info) { }
+            }
+
+            val verification = UpdateVerifier().verify(staged, info.asset)
+            if (verification !is VerificationResult.Success) {
+                staged.delete()
+                logger.severe("Verification failed, aborting install: $verification")
+                return EXIT_ERROR
+            }
+
+            return when (val launch = runBlocking { UpdateInstaller().launchUpdater(staged) }) {
+                is UpdateInstaller.LaunchResult.Success -> {
+                    logger.info("Updater launched — Morphe will restart on v${info.latestVersion} shortly.")
+                    // Mirrors the GUI's exit-immediately-after-launch contract: the
+                    // spawned updater is waiting on this process's PID to disappear.
+                    kotlin.system.exitProcess(EXIT_OK)
+                }
+                is UpdateInstaller.LaunchResult.Unsupported -> {
+                    logger.severe(launch.reason)
+                    EXIT_ERROR
+                }
+                is UpdateInstaller.LaunchResult.Failure -> {
+                    logger.severe(launch.reason)
+                    EXIT_ERROR
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/app/morphe/desktop/command/utility/SelfUpdateApplyCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/utility/SelfUpdateApplyCommand.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.desktop.command.utility
+
+import app.morphe.engine.isWindows
+import app.morphe.engine.update.UpdateVerifier
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import java.io.File
+import java.util.logging.Logger
+import kotlin.system.exitProcess
+
+/**
+ * The "external updater process" from the self-update architecture ([see
+ * app.morphe.engine.update.UpdateInstaller][app.morphe.engine.update.UpdateInstaller]
+ * for why this is a hidden subcommand of the same JAR rather than a
+ * separate artifact, and for why it's launched from a throwaway *copy* of
+ * the currently-running JAR rather than from `--staged` directly).
+ *
+ * Not intended for interactive use — `hidden = true` keeps it out of
+ * `--help`. [app.morphe.engine.update.UpdateInstaller] is the only caller,
+ * always with all three options set.
+ *
+ * This command treats `--staged` (the downloaded JAR) purely as bytes to
+ * copy into place — it is never executed, here or anywhere else in this
+ * flow, which is precisely what makes the update bootstrap-safe: this
+ * command's own behavior is entirely determined by the version that is
+ * *running* it (always the current, already-updater-aware release, per
+ * [app.morphe.engine.update.UpdateInstaller]), never by whatever the
+ * downloaded release happens to contain.
+ *
+ * Safety invariant this command exists to uphold: **the user is never left
+ * without a working installation.** Every failure path restores the backup
+ * and relaunches the previously-running (old) JAR rather than leaving
+ * [target] missing, half-written, or pointed at a corrupt file.
+ */
+@Command(
+    name = "self-update-apply",
+    description = ["Internal: apply a downloaded self-update. Not for interactive use."],
+    hidden = true,
+)
+internal object SelfUpdateApplyCommand : Runnable {
+
+    private val logger = Logger.getLogger(SelfUpdateApplyCommand::class.java.name)
+    private val verifier = UpdateVerifier()
+
+    @Option(names = ["--target"], required = true, description = ["JAR to replace (the running installation)."])
+    private lateinit var target: File
+
+    @Option(names = ["--staged"], required = true, description = ["Already-downloaded, already-verified new JAR."])
+    private lateinit var staged: File
+
+    @Option(names = ["--pid"], required = true, description = ["PID of the process that spawned this updater; waited on before touching target."])
+    private var pid: Long = -1
+
+    override fun run() {
+        logger.info("self-update-apply: target=${target.absolutePath} staged=${staged.absolutePath} waiting on pid=$pid")
+
+        if (!waitForExit(pid)) {
+            // The launching process never terminated within the timeout — it
+            // may still be holding the target file open. Touching it now
+            // risks corrupting a working install, so we abort without
+            // relaunching (the original process is presumably still running
+            // and doesn't need us to).
+            logger.severe("self-update-apply: pid $pid did not exit in time — aborting without touching $target")
+            exitProcess(1)
+        }
+
+        val backup = File(target.parentFile, "${target.name}.bak")
+
+        try {
+            if (!staged.exists()) error("staged file vanished: ${staged.absolutePath}")
+
+            logger.info("self-update-apply: backing up ${target.name} -> ${backup.name}")
+            if (backup.exists()) backup.delete()
+            if (target.exists()) target.copyTo(backup, overwrite = true)
+
+            logger.info("self-update-apply: replacing ${target.absolutePath}")
+            replace(staged, target)
+
+            if (!verifier.isReadableArchive(target)) {
+                error("replacement at ${target.absolutePath} failed integrity check after copy")
+            }
+
+            logger.info("self-update-apply: replacement verified — cleaning up and relaunching new version")
+            backup.delete()
+            runCatching { staged.delete() }
+
+            relaunch(target)
+            logger.info("self-update-apply: done")
+            exitProcess(0)
+        } catch (e: Exception) {
+            logger.severe("self-update-apply: FAILED (${e.message}) — rolling back")
+            rollbackAndRelaunch(target, backup)
+            exitProcess(1)
+        }
+    }
+
+    /** Poll [ProcessHandle] for [pid] to disappear. True if it exited within the timeout. */
+    private fun waitForExit(pid: Long, timeoutMs: Long = 60_000, pollMs: Long = 200): Boolean {
+        val handle = ProcessHandle.of(pid).orElse(null) ?: return true // already gone
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (handle.isAlive) {
+            if (System.currentTimeMillis() > deadline) return false
+            Thread.sleep(pollMs)
+        }
+        return true
+    }
+
+    /**
+     * Move [from] to [to], falling back to copy+delete when the two paths
+     * aren't on the same filesystem (rename then fails atomically rather
+     * than partially, per [File.renameTo]'s contract — so the fallback is
+     * always safe to attempt).
+     */
+    private fun replace(from: File, to: File) {
+        if (to.exists() && !to.delete()) {
+            error("could not remove existing file at ${to.absolutePath} (permissions?)")
+        }
+        if (!from.renameTo(to)) {
+            from.copyTo(to, overwrite = true)
+            from.delete()
+        }
+    }
+
+    /** Restore [backup] over [target] (best-effort) and relaunch whatever ends up there. */
+    private fun rollbackAndRelaunch(target: File, backup: File) {
+        if (backup.exists()) {
+            runCatching {
+                if (target.exists()) target.delete()
+                backup.copyTo(target, overwrite = true)
+                logger.info("self-update-apply: restored backup to ${target.absolutePath}")
+            }.onFailure {
+                logger.severe("self-update-apply: rollback copy failed: ${it.message} — $target may be unusable")
+            }
+        }
+        if (target.exists()) {
+            relaunch(target)
+        } else {
+            logger.severe("self-update-apply: no working JAR left at ${target.absolutePath} — user must reinstall")
+        }
+    }
+
+    /** Spawn `java -jar <jar>` detached (no args → GUI mode), independent of this process's lifetime. */
+    private fun relaunch(jar: File) {
+        val javaBin = File(File(System.getProperty("java.home"), "bin"), if (isWindows()) "java.exe" else "java")
+        try {
+            ProcessBuilder(javaBin.absolutePath, "-jar", jar.absolutePath)
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectErrorStream(true)
+                .start()
+        } catch (e: Exception) {
+            logger.severe("self-update-apply: failed to relaunch ${jar.absolutePath}: ${e.message}")
+        }
+    }
+}

--- a/src/main/kotlin/app/morphe/desktop/command/utility/UtilityCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/utility/UtilityCommand.kt
@@ -10,6 +10,13 @@ import picocli.CommandLine
 @CommandLine.Command(
     name = "utility",
     description = ["Commands for utility purposes."],
-    subcommands = [InstallCommand::class, UninstallCommand::class, ClearCacheCommand::class],
+    subcommands = [
+        InstallCommand::class,
+        UninstallCommand::class,
+        ClearCacheCommand::class,
+        // Internal: spawned by UpdateInstaller as the detached updater
+        // process, never invoked directly by a user. Hidden from --help.
+        SelfUpdateApplyCommand::class,
+    ],
 )
 internal object UtilityCommand

--- a/src/main/kotlin/app/morphe/engine/MorpheData.kt
+++ b/src/main/kotlin/app/morphe/engine/MorpheData.kt
@@ -100,6 +100,18 @@ object MorpheData {
     val importedKeystoreFile: File get() = File(root, "imported.keystore")
 
     /**
+     * The live [File] this JVM is actually running from, or null when
+     * launched from an IDE/classpath (`./gradlew run`, tests, etc.) where
+     * there's no JAR to speak of. Symlinks are resolved (see
+     * [resolveJarFile]) so this always points at the real on-disk file.
+     *
+     * Used by the self-updater ([app.morphe.engine.update.UpdateInstaller])
+     * to know which file to replace — self-update is unsupported when this
+     * is null, since there's nothing to overwrite.
+     */
+    val currentJarFile: File? by lazy { resolveJarFile() }
+
+    /**
      * Reason the primary (JAR-adjacent) location was rejected. Drives the
      * fallback log message so a user reporting "where's my cache?" can
      * tell from logs alone which branch ran.
@@ -135,27 +147,16 @@ object MorpheData {
      * The reason gets surfaced in logs so users can tell WHY we fell back.
      */
     private fun tryJarAdjacent(): Pair<File?, FallbackReason?> {
-        val location = try {
-            MorpheData::class.java.protectionDomain.codeSource?.location
-                ?: return null to FallbackReason.NO_JAR_LOCATION
-        } catch (e: Exception) {
-            return null to FallbackReason.EXCEPTION
-        }
-
-        val jarFile = try {
-            // canonicalFile resolves symlinks — Homebrew/asdf-style installs
-            // often symlink the JAR; we want the cache next to the real file,
-            // not next to the symlink.
-            File(location.toURI()).canonicalFile
-        } catch (e: Exception) {
-            return null to FallbackReason.EXCEPTION
-        }
-
-        // When running from IDE (`./gradlew run`), location is a classes
-        // directory, not a JAR. Detect and fall back so we don't pollute
-        // build outputs that `./gradlew clean` wipes.
-        if (jarFile.isDirectory || !jarFile.name.endsWith(".jar")) {
-            return null to FallbackReason.NOT_A_JAR
+        val jarFile = resolveJarFile() ?: run {
+            // Distinguish "no codeSource at all" from "codeSource isn't a JAR"
+            // only for logging purposes — re-probe cheaply since resolveJarFile
+            // already swallows the exception cases into null.
+            val hasLocation = try {
+                MorpheData::class.java.protectionDomain.codeSource?.location != null
+            } catch (e: Exception) {
+                return null to FallbackReason.EXCEPTION
+            }
+            return null to if (hasLocation) FallbackReason.NOT_A_JAR else FallbackReason.NO_JAR_LOCATION
         }
 
         val candidate = File(jarFile.parentFile, "morphe-data")
@@ -163,6 +164,28 @@ object MorpheData {
             return null to FallbackReason.NOT_WRITABLE
         }
         return candidate to null
+    }
+
+    /**
+     * Resolve the JAR this JVM's code was loaded from, or null when running
+     * from a classes directory (IDE/tests) or the codeSource is unavailable.
+     * Symlinks are resolved via [File.getCanonicalFile] — Homebrew/asdf-style
+     * installs often symlink the JAR, and callers want the real file.
+     */
+    private fun resolveJarFile(): File? {
+        val location = try {
+            MorpheData::class.java.protectionDomain.codeSource?.location ?: return null
+        } catch (e: Exception) {
+            return null
+        }
+        val file = try {
+            File(location.toURI()).canonicalFile
+        } catch (e: Exception) {
+            return null
+        }
+        // When running from IDE (`./gradlew run`), location is a classes
+        // directory, not a JAR — not something a self-update can replace.
+        return file.takeIf { !it.isDirectory && it.name.endsWith(".jar") }
     }
 
     private fun userHomeFallback(): File {

--- a/src/main/kotlin/app/morphe/engine/update/SelfUpdateChecker.kt
+++ b/src/main/kotlin/app/morphe/engine/update/SelfUpdateChecker.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine.update
+
+import app.morphe.engine.ReleaseChannel
+import app.morphe.engine.UpdateChecker
+import app.morphe.engine.model.Release
+import app.morphe.engine.network.HttpService
+import app.morphe.engine.patches.GitHubPatchSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.logging.Logger
+
+/**
+ * Resolves a full [UpdateReleaseInfo] (release notes, publish date, asset,
+ * download URL, size) for the desktop app's own GitHub repository.
+ *
+ * Deliberately reuses [GitHubPatchSource] instead of hand-rolling a second
+ * "talk to the GitHub releases API" client: patch sources already fetch,
+ * retry, and parse `GET /repos/{owner}/{repo}/releases` into [Release] /
+ * [app.morphe.engine.model.ReleaseAsset] — pointing that same client at
+ * `MorpheApp/morphe-desktop` gets the desktop app's own releases for free,
+ * with identical retry/429/error handling.
+ *
+ * [app.morphe.engine.UpdateChecker] (the pre-existing lightweight banner
+ * check against `gradle.properties`) is untouched and still used where only
+ * a yes/no + version string is needed — this class is additive, used by the
+ * richer download-in-app flow.
+ */
+object SelfUpdateChecker {
+
+    /** owner/repo this build ships from. Matches [UpdateChecker]'s hardcoded repo. */
+    private const val REPO_PATH = "MorpheApp/morphe-desktop"
+
+    private val logger = Logger.getLogger(SelfUpdateChecker::class.java.name)
+
+    /**
+     * Fetch the newest release on [channel] that both (a) is newer than the
+     * running build and (b) has a JAR asset to download. Returns `null` when
+     * already up to date, the resource is unavailable, or a channel-eligible
+     * release exists but ships no usable asset (never surfaces a dead-end
+     * update to the user).
+     */
+    suspend fun fetchLatest(http: HttpService, channel: ReleaseChannel): Result<UpdateReleaseInfo?> =
+        withContext(Dispatchers.IO) {
+            val currentVersion = UpdateChecker.currentVersion()
+                ?: return@withContext Result.success(null)
+
+            val source = GitHubPatchSource(http, REPO_PATH)
+            val releasesResult = source.listReleases()
+            val releases = releasesResult.getOrElse { e ->
+                logger.warning("SelfUpdateChecker: failed to list releases: ${e.message}")
+                return@withContext Result.failure(e)
+            }
+
+            val candidate = releases
+                .asSequence()
+                .filterNot { it.draft }
+                .filter { release ->
+                    when (channel) {
+                        // Stable users only ever see non-prerelease tags.
+                        ReleaseChannel.STABLE -> !release.isDevRelease()
+                        // Dev users ride the newest release overall — GitHub
+                        // returns releases newest-first, so the first
+                        // non-draft entry (stable or dev) is what "dev
+                        // channel" means: never behind, never skips a stable.
+                        ReleaseChannel.DEV -> true
+                    }
+                }
+                .firstOrNull()
+                ?: return@withContext Result.success(null)
+
+            if (candidate.getVersion() == currentVersion) {
+                return@withContext Result.success(null)
+            }
+
+            val asset = candidate.assets.firstOrNull { it.name.endsWith(".jar", ignoreCase = true) }
+            if (asset == null) {
+                logger.warning(
+                    "SelfUpdateChecker: release ${candidate.tagName} has no .jar asset — skipping in-app update"
+                )
+                return@withContext Result.success(null)
+            }
+
+            Result.success(
+                UpdateReleaseInfo(
+                    currentVersion = currentVersion,
+                    release = candidate,
+                    asset = asset,
+                    channel = channel,
+                )
+            )
+        }
+}

--- a/src/main/kotlin/app/morphe/engine/update/UpdateDownloadManager.kt
+++ b/src/main/kotlin/app/morphe/engine/update/UpdateDownloadManager.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine.update
+
+import app.morphe.engine.MorpheData
+import app.morphe.engine.model.ReleaseAsset
+import app.morphe.engine.network.HttpService
+import io.ktor.client.request.headers
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.CancellationException
+import java.io.File
+import java.util.logging.Logger
+
+/**
+ * Progress snapshot for an in-flight update download.
+ *
+ * @param bytesRead bytes written to disk so far.
+ * @param totalBytes total expected size, or null when the server didn't send
+ *   `Content-Length` (progress/percent are then indeterminate).
+ * @param bytesPerSecond instantaneous throughput since the previous snapshot.
+ * @param etaSeconds estimated seconds remaining, or null when [totalBytes] is
+ *   unknown or throughput hasn't stabilized yet.
+ */
+data class DownloadProgress(
+    val bytesRead: Long,
+    val totalBytes: Long?,
+    val bytesPerSecond: Long,
+    val etaSeconds: Long?,
+) {
+    /** 0f..1f, or null when [totalBytes] is unknown (server omitted Content-Length). */
+    val fraction: Float? get() = totalBytes?.takeIf { it > 0 }?.let { (bytesRead.toDouble() / it).toFloat() }
+}
+
+/**
+ * Downloads a self-update [ReleaseAsset] to a staging file. Only responsible
+ * for the transfer itself — verification is [UpdateVerifier]'s job,
+ * installation is [UpdateInstaller]'s.
+ *
+ * All the hard parts (streaming to disk with constant memory, retry with
+ * exponential backoff, HTTP 429 handling) already live in [HttpService] —
+ * this class only adds speed/ETA bookkeeping on top of its progress
+ * callback, matching the "never load the file into memory" and "retry with
+ * backoff" requirements without re-implementing them.
+ *
+ * Cancellation: callers cancel the enclosing coroutine (structured
+ * concurrency) rather than a bespoke flag — [HttpService.downloadToFile]
+ * already cleans up its partial `.part` file on [CancellationException] (see
+ * its `catch (t: Throwable)` cleanup block), so cancelling here never leaves
+ * a corrupt partial file at the staging path.
+ */
+class UpdateDownloadManager(private val http: HttpService) {
+
+    private val logger = Logger.getLogger(UpdateDownloadManager::class.java.name)
+
+    /**
+     * Staging directory for in-progress/completed self-update downloads.
+     * JAR-adjacent (survives being separate from the patches/logs the user
+     * might clear) but still inside the portable data root.
+     */
+    private val stagingDir: File by lazy { File(MorpheData.tmpDir, "self-update").also { it.mkdirs() } }
+
+    /**
+     * Where [asset] for [version] will be staged. Deterministic so a resumed
+     * app session can detect "already downloaded" without re-fetching (see
+     * [stagedFileIfComplete]).
+     */
+    fun stagedFileFor(version: String, asset: ReleaseAsset): File =
+        File(stagingDir, "morphe-desktop-$version-${asset.id.takeIf { it != 0L } ?: asset.name.hashCode()}.jar")
+
+    /**
+     * Returns the staged file for [info] if it already exists on disk with
+     * the exact expected size — lets a re-opened update dialog skip
+     * straight to "ready to install" instead of re-downloading. Does not
+     * open the archive; callers should still run [UpdateVerifier] before
+     * trusting this file for installation, since a same-size file could
+     * still be a stale/corrupt leftover in rare cases.
+     */
+    fun stagedFileIfComplete(info: UpdateReleaseInfo): File? {
+        val file = stagedFileFor(info.latestVersion, info.asset)
+        if (!file.exists()) return null
+        if (info.asset.size > 0 && file.length() != info.asset.size) return null
+        return file
+    }
+
+    /**
+     * Download [info]'s asset to its staging location, reporting
+     * [DownloadProgress] via [onProgress]. Throws on failure (propagated
+     * from [HttpService], already retried internally); callers should catch
+     * and surface via their own error state.
+     */
+    suspend fun download(
+        info: UpdateReleaseInfo,
+        onProgress: (DownloadProgress) -> Unit,
+    ): File {
+        val target = stagedFileFor(info.latestVersion, info.asset)
+        logger.info("UpdateDownloadManager: downloading ${info.asset.name} -> ${target.absolutePath}")
+
+        var lastBytes = 0L
+        var lastAt = System.currentTimeMillis()
+
+        try {
+            http.downloadToFile(
+                url = info.asset.downloadUrl,
+                saveLocation = target,
+                onProgress = { bytesRead, contentLength ->
+                    val now = System.currentTimeMillis()
+                    val elapsedMs = (now - lastAt).coerceAtLeast(1)
+                    val deltaBytes = (bytesRead - lastBytes).coerceAtLeast(0)
+                    val bytesPerSecond = (deltaBytes * 1000) / elapsedMs
+                    val total = contentLength ?: info.asset.size.takeIf { it > 0 }
+                    val remaining = total?.let { (it - bytesRead).coerceAtLeast(0) }
+                    val eta = if (bytesPerSecond > 0 && remaining != null) remaining / bytesPerSecond else null
+
+                    lastBytes = bytesRead
+                    lastAt = now
+
+                    onProgress(DownloadProgress(bytesRead, total, bytesPerSecond, eta))
+                },
+            ) {
+                headers { append(HttpHeaders.Accept, "application/octet-stream") }
+            }
+        } catch (e: CancellationException) {
+            logger.info("UpdateDownloadManager: download cancelled")
+            throw e
+        } catch (e: Exception) {
+            logger.warning("UpdateDownloadManager: download failed: ${e.message}")
+            throw e
+        }
+
+        return target
+    }
+
+    /** Remove any staged self-update downloads (called after a successful install, or from Settings). */
+    fun clearStaging() {
+        runCatching { stagingDir.listFiles()?.forEach { it.delete() } }
+    }
+}

--- a/src/main/kotlin/app/morphe/engine/update/UpdateInstaller.kt
+++ b/src/main/kotlin/app/morphe/engine/update/UpdateInstaller.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine.update
+
+import app.morphe.engine.MorpheData
+import app.morphe.engine.isWindows
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.logging.Logger
+
+/**
+ * Coordinates handing a verified, staged update JAR off to a **separate
+ * process** that performs the actual file replacement — this class itself
+ * never overwrites the running JAR (a running process can't safely replace
+ * its own backing file on every platform, and Windows will outright refuse
+ * to on most JVMs since the file is memory-mapped/locked).
+ *
+ * ## Why the updater runs from a copy of the *current* JAR, not the downloaded one
+ *
+ * Earlier revisions of this class launched the **downloaded** JAR itself as
+ * the updater process (`java -jar <stagedJar> utility self-update-apply
+ * ...`), reasoning that shipping a second updater artifact was unnecessary
+ * duplication. That reasoning about avoiding a second artifact still holds —
+ * but launching the *downloaded* JAR specifically was wrong, for two
+ * independent reasons:
+ *
+ *  1. **Bootstrap dependency.** It made every update silently depend on the
+ *     *target* version already containing `self-update-apply`. The very
+ *     first updater-enabled release has nothing upstream that satisfies
+ *     that — the downloaded JAR exits with "Unknown command" and the update
+ *     fails. More generally, it coupled "can I update?" to the internals of
+ *     whatever happens to be the latest upstream release, which this class
+ *     has no control over.
+ *  2. **Self-lock on Windows.** Even ignoring (1), if the downloaded JAR
+ *     *did* contain the updater and were launched in place, replacing
+ *     [MorpheData.currentJarFile] would still need the *updater process
+ *     itself* to not be the thing holding that file open — but the running
+ *     app is the one being replaced, and Windows won't let anything delete
+ *     or overwrite a JAR a live JVM loaded classes from.
+ *
+ * The fix addresses both at once: [launchUpdater] copies
+ * [MorpheData.currentJarFile] — the version that's *actually running right
+ * now*, which by definition already contains this exact updater code — to a
+ * disposable temp file, and launches **that copy** with `utility
+ * self-update-apply`. The downloaded JAR ([stagedJar]) is passed only as
+ * `--staged`, a plain path the updater process copies bytes from; it is
+ * never executed, so it doesn't matter whether it contains updater code,
+ * an older format, or nothing update-related at all. And because the
+ * updater process runs from a copy rather than from
+ * [MorpheData.currentJarFile] directly, it holds no lock on the file it
+ * needs to replace.
+ *
+ * The net result: **any version that has this fix can update to any other
+ * version**, regardless of what the other version contains. Compare to how
+ * IntelliJ/JetBrains Toolbox and VS Code updaters work — the *installed*
+ * app always drives its own update using its own bundled updater, and the
+ * downloaded payload is inert data until installed.
+ *
+ * ## Why still no second artifact
+ *
+ * The updater process is still just this same JAR (via the hidden
+ * [app.morphe.desktop.command.utility.SelfUpdateApplyCommand] subcommand)
+ * rather than a dedicated updater binary — morphe-desktop's release
+ * pipeline ships exactly one asset (see `.releaserc`), and a second
+ * artifact would need its own build/sign/version story for no real benefit
+ * here. The only change is *which copy* of this JAR plays that role.
+ *
+ * Flow:
+ * 1. [launchUpdater] copies [MorpheData.currentJarFile] to a throwaway file
+ *    and launches it as `java -jar <copy> utility self-update-apply
+ *    --target <currentJarFile> --staged <stagedJar> --pid <ourPid>`, detached.
+ * 2. The caller (GUI ViewModel / CLI command) then exits the current
+ *    process — the spawned process is waiting on our PID to disappear
+ *    before it will touch [MorpheData.currentJarFile].
+ * 3. That process backs up the target, replaces it with the bytes from
+ *    `--staged`, verifies the replacement, and relaunches — restoring the
+ *    backup and relaunching the *old* JAR instead if anything went wrong.
+ *    See [app.morphe.cli.command.utility.SelfUpdateApplyCommand] for that
+ *    half — it is unchanged by this fix, since it already only ever reads
+ *    `--staged` as data and never executed it.
+ */
+class UpdateInstaller {
+
+    private val logger = Logger.getLogger(UpdateInstaller::class.java.name)
+
+    /**
+     * Launch the detached updater process for [stagedJar]. Does **not**
+     * exit the current process — callers must do that themselves right
+     * after a [LaunchResult.Success] (see class doc for why the ordering
+     * matters).
+     *
+     * Runs on [Dispatchers.IO]: preparing the updater copy copies the
+     * entire running JAR (tens of MB), which would otherwise block the
+     * caller's dispatcher.
+     */
+    suspend fun launchUpdater(stagedJar: File): LaunchResult = withContext(Dispatchers.IO) {
+        val targetJar = MorpheData.currentJarFile
+            ?: return@withContext LaunchResult.Unsupported(
+                "Not running from a packaged JAR (IDE/dev run) — self-update can't replace anything."
+            )
+        if (!stagedJar.exists()) {
+            return@withContext LaunchResult.Failure("Staged update file is missing: ${stagedJar.absolutePath}")
+        }
+
+        val javaBin = resolveJavaBinary()
+            ?: return@withContext LaunchResult.Failure("Could not locate the Java runtime (java.home unset).")
+
+        // Best-effort: clear out copies left behind by a previous attempt
+        // (e.g. one that crashed before relaunching) before adding a new
+        // one. Never fails the current update if this can't fully clean up —
+        // a few stray MB in the temp dir is harmless.
+        sweepOrphanedUpdaterCopies()
+
+        val updaterCopy = try {
+            makeUpdaterCopy(targetJar)
+        } catch (e: Exception) {
+            logger.severe("UpdateInstaller: failed to prepare updater copy: ${e.message}")
+            return@withContext LaunchResult.Failure("Could not prepare the updater: ${e.message}")
+        }
+
+        val ourPid = ProcessHandle.current().pid()
+        val logFile = File(MorpheData.logsDir, "self-update.log")
+
+        // Note --target and the running JAR (`-jar updaterCopy`) are
+        // deliberately different files — see class doc, "Self-lock on
+        // Windows". `--staged` (the downloaded JAR) is passed as inert data
+        // and is never executed by anything in this flow.
+        val command = listOf(
+            javaBin.absolutePath,
+            "-jar", updaterCopy.absolutePath,
+            "utility", "self-update-apply",
+            "--target", targetJar.absolutePath,
+            "--staged", stagedJar.absolutePath,
+            "--pid", ourPid.toString(),
+        )
+
+        return@withContext try {
+            logger.info("UpdateInstaller: launching updater process: ${command.joinToString(" ")}")
+            ProcessBuilder(command)
+                .redirectOutput(ProcessBuilder.Redirect.appendTo(logFile))
+                .redirectErrorStream(true)
+                // No inheritIO / no waitFor: this must survive and keep
+                // running after the current (parent) process exits.
+                .start()
+            LaunchResult.Success
+        } catch (e: Exception) {
+            logger.severe("UpdateInstaller: failed to launch updater process: ${e.message}")
+            LaunchResult.Failure("Could not start the updater process: ${e.message}")
+        }
+    }
+
+    /**
+     * Copy [targetJar] (the running installation) to a fresh, uniquely
+     * named file in [updaterCopyDir]. This copy — not [targetJar] itself —
+     * is what actually gets launched as the updater process; see class doc.
+     */
+    private fun makeUpdaterCopy(targetJar: File): File {
+        val dir = updaterCopyDir().also { it.mkdirs() }
+        val copy = File(dir, "updater-${System.currentTimeMillis()}-${ProcessHandle.current().pid()}.jar")
+        targetJar.copyTo(copy, overwrite = true)
+        return copy
+    }
+
+    /**
+     * Delete any updater copies left over from earlier update attempts.
+     * Safe to call any time: a copy is only ever needed for the few moments
+     * between being spawned and relaunching the new version, so anything
+     * still present here by the time a *new* update starts is orphaned —
+     * most commonly because the process that made it crashed, or the
+     * machine lost power, before it could relaunch and exit cleanly. This
+     * process (not the orphaned one) still holds no lock on these files, so
+     * deleting them here is always safe.
+     */
+    private fun sweepOrphanedUpdaterCopies() {
+        runCatching { updaterCopyDir().listFiles()?.forEach { it.delete() } }
+    }
+
+    private fun updaterCopyDir(): File = File(MorpheData.tmpDir, "self-update/updater-copies")
+
+    /**
+     * `<java.home>/bin/java[.exe]` — the exact JVM currently running us, so
+     * the spawned process needs no PATH lookup and matches our toolchain.
+     */
+    private fun resolveJavaBinary(): File? {
+        val javaHome = System.getProperty("java.home") ?: return null
+        val binName = if (isWindows()) "java.exe" else "java"
+        val bin = File(File(javaHome, "bin"), binName)
+        return bin.takeIf { it.exists() }
+    }
+
+    sealed class LaunchResult {
+        object Success : LaunchResult()
+        data class Unsupported(val reason: String) : LaunchResult()
+        data class Failure(val reason: String) : LaunchResult()
+    }
+}

--- a/src/main/kotlin/app/morphe/engine/update/UpdateReleaseInfo.kt
+++ b/src/main/kotlin/app/morphe/engine/update/UpdateReleaseInfo.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine.update
+
+import app.morphe.engine.ReleaseChannel
+import app.morphe.engine.model.Release
+import app.morphe.engine.model.ReleaseAsset
+
+/**
+ * A fully-resolved self-update candidate: the running build's version, the
+ * [Release] it would update to, the specific [asset] (the shadow JAR) to
+ * download, and which [channel] the check was made against.
+ *
+ * This is the richer counterpart to [app.morphe.engine.UpdateInfo] — that
+ * type only carries enough to render the lightweight banner (which links out
+ * to the releases page); this type carries everything [UpdateDownloadManager],
+ * [UpdateVerifier], and the GUI's update dialog need to actually fetch and
+ * install the update in-app.
+ */
+data class UpdateReleaseInfo(
+    val currentVersion: String,
+    val release: Release,
+    val asset: ReleaseAsset,
+    val channel: ReleaseChannel,
+) {
+    val latestVersion: String get() = release.getVersion()
+}

--- a/src/main/kotlin/app/morphe/engine/update/UpdateVerifier.kt
+++ b/src/main/kotlin/app/morphe/engine/update/UpdateVerifier.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine.update
+
+import app.morphe.engine.model.ReleaseAsset
+import java.io.File
+import java.security.MessageDigest
+import java.util.logging.Logger
+import java.util.zip.ZipException
+import java.util.zip.ZipFile
+
+/**
+ * Outcome of verifying a downloaded update file. A sealed result (rather
+ * than a boolean) so [UpdateInstaller] and the GUI can show a specific,
+ * actionable reason instead of a generic "verification failed".
+ */
+sealed class VerificationResult {
+    /** Verification passed. [sha256] is recorded for diagnostics/future signature checks. */
+    data class Success(val sha256: String) : VerificationResult()
+
+    /** Downloaded size didn't match the size GitHub reported for the asset. */
+    data class SizeMismatch(val expected: Long, val actual: Long) : VerificationResult()
+
+    /** File isn't a well-formed ZIP/JAR — truncated or corrupted in transit. */
+    data class CorruptArchive(val reason: String) : VerificationResult()
+
+    /** Digest published for this release didn't match ([UpdateVerifier.CHECKSUM_ASSET_NAMES] — currently unused by upstream releases, kept for forward compatibility). */
+    data class ChecksumMismatch(val expected: String, val actual: String) : VerificationResult()
+
+    data class Error(val message: String) : VerificationResult()
+
+    val isSuccess: Boolean get() = this is Success
+}
+
+/**
+ * Verifies a downloaded self-update JAR before [UpdateInstaller] is allowed
+ * to touch the running installation.
+ *
+ * Three checks, cheapest/most-certain first:
+ *  1. **Size** — the byte count GitHub reports for the asset ([ReleaseAsset.size])
+ *     must match what actually landed on disk. Catches truncated transfers
+ *     HttpService's own retry didn't already reject.
+ *  2. **Archive integrity** — the file must open as a well-formed ZIP with a
+ *     readable central directory. A shadow JAR that fails this is corrupt
+ *     regardless of size.
+ *  3. **SHA-256** — always computed and returned in [VerificationResult.Success]
+ *     so it's logged and available for support/debugging. Not currently
+ *     compared against anything published upstream (morphe-desktop's release
+ *     pipeline — see `.releaserc` — ships only the JAR, no checksum
+ *     manifest). Wiring one up later needs no redesign: detect a release
+ *     asset named anything in [CHECKSUM_ASSET_NAMES], download it, and
+ *     compare — a few lines added to [verify], nothing else touched.
+ *     Digital-signature verification (detached `.asc`/`.sig`) can be added
+ *     the same way: a new asset-name convention checked here, without
+ *     touching [UpdateDownloadManager] or [UpdateInstaller].
+ */
+class UpdateVerifier {
+
+    private val logger = Logger.getLogger(UpdateVerifier::class.java.name)
+
+    /** Full verification pipeline: size → archive integrity → digest. */
+    fun verify(file: File, asset: ReleaseAsset): VerificationResult {
+        if (asset.size > 0 && file.length() != asset.size) {
+            logger.warning("UpdateVerifier: size mismatch — expected ${asset.size}, got ${file.length()}")
+            return VerificationResult.SizeMismatch(asset.size, file.length())
+        }
+
+        val integrityError = checkArchiveIntegrity(file)
+        if (integrityError != null) {
+            logger.warning("UpdateVerifier: corrupt archive — $integrityError")
+            return VerificationResult.CorruptArchive(integrityError)
+        }
+
+        val digest = try {
+            sha256(file)
+        } catch (e: Exception) {
+            logger.warning("UpdateVerifier: failed to hash downloaded file: ${e.message}")
+            return VerificationResult.Error("Could not compute checksum: ${e.message}")
+        }
+
+        logger.info("UpdateVerifier: ${file.name} OK (sha256=$digest)")
+        return VerificationResult.Success(digest)
+    }
+
+    /**
+     * Lightweight post-replacement sanity check — just "is this a readable
+     * ZIP/JAR", no size/checksum comparison. Used by
+     * [app.morphe.desktop.command.utility.SelfUpdateApplyCommand] to confirm the
+     * file it just moved into place on disk wasn't truncated by the copy
+     * itself, without re-running the full [verify] pipeline (the asset's
+     * expected size isn't available at that point — see that command's doc).
+     */
+    fun isReadableArchive(file: File): Boolean = file.exists() && checkArchiveIntegrity(file) == null
+
+    /**
+     * Opens [file] as a [ZipFile] and forces the central directory to be
+     * read. `ZipFile` validates the End-Of-Central-Directory record and
+     * every entry header on open, so a truncated or bit-flipped download
+     * throws here even though [File.length] might look plausible.
+     */
+    private fun checkArchiveIntegrity(file: File): String? {
+        return try {
+            ZipFile(file).use { zip ->
+                if (zip.entries().hasMoreElements().not()) "archive has no entries" else null
+            }
+        } catch (e: ZipException) {
+            e.message ?: "malformed ZIP/JAR"
+        } catch (e: Exception) {
+            e.message ?: "unreadable archive"
+        }
+    }
+
+    /** Streaming SHA-256 (64 KB chunks) — never loads the whole file into memory. */
+    private fun sha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    companion object {
+        /**
+         * Asset-name conventions a future checksum manifest might use.
+         * Purely forward-compatible today — morphe-desktop's release
+         * pipeline doesn't publish one yet (see class doc).
+         */
+        val CHECKSUM_ASSET_NAMES = setOf("checksums.txt", "SHA256SUMS", "checksums.sha256")
+    }
+}

--- a/src/main/kotlin/app/morphe/gui/data/model/AppConfig.kt
+++ b/src/main/kotlin/app/morphe/gui/data/model/AppConfig.kt
@@ -126,6 +126,14 @@ data class AppConfig(
     // (only applies when a rename patch was used and stock is installed). Default
     // OFF — it reaches into a stock app's behavior.
     val disableStockLinksAfterInstall: Boolean = false,
+    // When an update is found, start downloading it in the background immediately
+    // instead of waiting for the user to open the update dialog and press
+    // "Download & Install" — so by the time they do, it's often already staged
+    // and verified. Installing (replacing the JAR + restart) always still
+    // requires an explicit click; this only skips the wait on the download step.
+    // Default OFF — some users are on metered/slow connections and don't want
+    // background transfers they didn't ask for.
+    val autoDownloadUpdates: Boolean = false,
 ) {
 
     fun getUpdateChannelPreference(): UpdateChannelPreference? {

--- a/src/main/kotlin/app/morphe/gui/data/repository/ConfigRepository.kt
+++ b/src/main/kotlin/app/morphe/gui/data/repository/ConfigRepository.kt
@@ -176,6 +176,16 @@ class ConfigRepository {
     }
 
     /**
+     * Persist the "auto-download updates in the background" preference.
+     * See [AppConfig.autoDownloadUpdates] for what this does and doesn't
+     * skip.
+     */
+    suspend fun setAutoDownloadUpdates(enabled: Boolean) {
+        val current = loadConfig()
+        saveConfig(current.copy(autoDownloadUpdates = enabled))
+    }
+
+    /**
      * Resolve the update-channel preference. When the user has explicitly
      * picked one (via Settings), respect that. Otherwise re-derive from the
      * running build's version on every call so swapping between a stable and

--- a/src/main/kotlin/app/morphe/gui/data/repository/SelfUpdateRepository.kt
+++ b/src/main/kotlin/app/morphe/gui/data/repository/SelfUpdateRepository.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.gui.data.repository
+
+import app.morphe.engine.ReleaseChannel
+import app.morphe.engine.network.HttpService
+import app.morphe.engine.update.DownloadProgress
+import app.morphe.engine.update.SelfUpdateChecker
+import app.morphe.engine.update.UpdateDownloadManager
+import app.morphe.engine.update.UpdateInstaller
+import app.morphe.engine.update.UpdateReleaseInfo
+import app.morphe.engine.update.UpdateVerifier
+import app.morphe.engine.update.VerificationResult
+import app.morphe.gui.data.model.UpdateChannelPreference
+import app.morphe.gui.util.Logger
+import io.ktor.client.HttpClient
+import java.io.File
+
+/**
+ * GUI façade over the engine's self-update pieces. Mirrors
+ * [UpdateCheckRepository]'s role for the lightweight banner check, but for
+ * the richer in-app download-and-install flow: [SelfUpdateDialog][app.morphe.gui.ui.components.SelfUpdateDialog]
+ * calls this, this delegates to [app.morphe.engine.update], nothing else in
+ * the GUI touches those classes directly.
+ *
+ * Deliberately stateless between calls (no cached "current download job" —
+ * that lifecycle belongs to whatever Composable/ViewModel started it, which
+ * can cancel by cancelling its own coroutine). Keeps this safe to inject as
+ * a Koin `single` without worrying about two dialogs racing.
+ */
+class SelfUpdateRepository(httpClient: HttpClient) {
+
+    private val http = HttpService(httpClient)
+    private val downloadManager = UpdateDownloadManager(http)
+    private val verifier = UpdateVerifier()
+    private val installer = UpdateInstaller()
+
+    suspend fun checkForUpdate(preference: UpdateChannelPreference): UpdateReleaseInfo? {
+        if (preference == UpdateChannelPreference.OFF) return null
+        val channel = when (preference) {
+            UpdateChannelPreference.STABLE -> ReleaseChannel.STABLE
+            UpdateChannelPreference.DEV -> ReleaseChannel.DEV
+            UpdateChannelPreference.OFF -> return null
+        }
+        return SelfUpdateChecker.fetchLatest(http, channel)
+            .onFailure { Logger.error("SelfUpdateRepository: check failed", it) }
+            .getOrNull()
+    }
+
+    /** A previously-downloaded staged file for [info], if one exists on disk with the right size. */
+    fun alreadyStaged(info: UpdateReleaseInfo): File? = downloadManager.stagedFileIfComplete(info)
+
+    suspend fun download(info: UpdateReleaseInfo, onProgress: (DownloadProgress) -> Unit): File =
+        downloadManager.download(info, onProgress)
+
+    fun verify(file: File, info: UpdateReleaseInfo): VerificationResult = verifier.verify(file, info.asset)
+
+    /**
+     * Hand [stagedJar] off to the detached updater process. On
+     * [UpdateInstaller.LaunchResult.Success] the caller MUST exit the
+     * application immediately after — the spawned process is waiting on
+     * this process's PID to disappear before it touches anything.
+     */
+    suspend fun launchInstaller(stagedJar: File): UpdateInstaller.LaunchResult = installer.launchUpdater(stagedJar)
+
+    fun clearStaging() = downloadManager.clearStaging()
+}

--- a/src/main/kotlin/app/morphe/gui/di/AppModule.kt
+++ b/src/main/kotlin/app/morphe/gui/di/AppModule.kt
@@ -8,6 +8,7 @@ package app.morphe.gui.di
 import app.morphe.gui.data.repository.ConfigRepository
 import app.morphe.gui.data.repository.PatchPreferencesRepository
 import app.morphe.gui.data.repository.PatchSourceManager
+import app.morphe.gui.data.repository.SelfUpdateRepository
 import app.morphe.gui.data.repository.UpdateCheckRepository
 import app.morphe.engine.PatchedAppStore
 import app.morphe.gui.util.PatchService
@@ -74,6 +75,7 @@ val appModule = module {
     single { PatchSourceManager(get(), get()) }
     single { PatchService() }
     single { UpdateCheckRepository(get()) }
+    single { SelfUpdateRepository(get()) }
     single { PatchedAppStore.shared }
 
     // ViewModels (ScreenModels)

--- a/src/main/kotlin/app/morphe/gui/ui/components/SelfUpdateDialog.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SelfUpdateDialog.kt
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.gui.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.NewReleases
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.morphe.engine.update.DownloadProgress
+import app.morphe.engine.update.UpdateInstaller
+import app.morphe.engine.update.UpdateReleaseInfo
+import app.morphe.engine.update.VerificationResult
+import app.morphe.gui.data.model.UpdateChannelPreference
+import app.morphe.gui.data.repository.SelfUpdateRepository
+import app.morphe.gui.ui.theme.LocalMorpheAccents
+import app.morphe.gui.ui.theme.LocalMorpheCorners
+import app.morphe.gui.ui.theme.LocalMorpheFont
+import app.morphe.gui.util.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.io.File
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import kotlin.system.exitProcess
+
+/**
+ * State machine for the dialog. Purely descriptive — every transition is
+ * driven by a suspend call into [SelfUpdateRepository]; this file has no
+ * update logic of its own beyond sequencing those calls (see [SelfUpdateDialog]).
+ */
+private sealed class SelfUpdatePhase {
+    object Checking : SelfUpdatePhase()
+    object UpToDate : SelfUpdatePhase()
+    data class Available(val info: UpdateReleaseInfo, val alreadyStaged: File?) : SelfUpdatePhase()
+    data class Downloading(val info: UpdateReleaseInfo, val progress: DownloadProgress?) : SelfUpdatePhase()
+    data class Verifying(val info: UpdateReleaseInfo) : SelfUpdatePhase()
+    data class Installing(val info: UpdateReleaseInfo) : SelfUpdatePhase()
+    data class Failed(val info: UpdateReleaseInfo?, val message: String) : SelfUpdatePhase()
+}
+
+/**
+ * Self-update dialog. Opened from [UpdateBanner]'s Download action.
+ *
+ * @param autoDownload when true (from [app.morphe.gui.data.model.AppConfig.autoDownloadUpdates]),
+ *   skips straight from [SelfUpdatePhase.Available] into downloading instead
+ *   of waiting for the user to press "Download & Install".
+ * @param onExitForInstall called right before the process exits to hand off
+ *   to the updater — lets the caller do any last Compose-side cleanup
+ *   (closing the window) before [exitProcess] runs. The dialog itself
+ *   performs the exit; there's no "installed" state to render because the
+ *   process is gone by the time installation actually happens.
+ */
+@Composable
+fun SelfUpdateDialog(
+    channel: UpdateChannelPreference,
+    autoDownload: Boolean,
+    repository: SelfUpdateRepository,
+    onDismiss: () -> Unit,
+    onExitForInstall: () -> Unit = {},
+) {
+    val corners = LocalMorpheCorners.current
+    val mono = LocalMorpheFont.current
+    val accents = LocalMorpheAccents.current
+    val scope = rememberCoroutineScope()
+
+    var phase by remember { mutableStateOf<SelfUpdatePhase>(SelfUpdatePhase.Checking) }
+    var downloadJob by remember { mutableStateOf<Job?>(null) }
+
+    fun startDownload(info: UpdateReleaseInfo) {
+        downloadJob = scope.launch {
+            phase = SelfUpdatePhase.Downloading(info, null)
+            try {
+                val file = repository.download(info) { progress ->
+                    phase = SelfUpdatePhase.Downloading(info, progress)
+                }
+                phase = SelfUpdatePhase.Verifying(info)
+                when (val result = repository.verify(file, info)) {
+                    is VerificationResult.Success -> {
+                        Logger.info("SelfUpdateDialog: verified ${file.name} (sha256=${result.sha256})")
+                        phase = SelfUpdatePhase.Installing(info)
+                        when (val launch = repository.launchInstaller(file)) {
+                            is UpdateInstaller.LaunchResult.Success -> {
+                                onExitForInstall()
+                                exitProcess(0)
+                            }
+                            is UpdateInstaller.LaunchResult.Unsupported ->
+                                phase = SelfUpdatePhase.Failed(info, launch.reason)
+                            is UpdateInstaller.LaunchResult.Failure ->
+                                phase = SelfUpdatePhase.Failed(info, launch.reason)
+                        }
+                    }
+                    else -> {
+                        Logger.error("SelfUpdateDialog: verification failed: $result")
+                        file.delete()
+                        phase = SelfUpdatePhase.Failed(info, result.describe())
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.error("SelfUpdateDialog: download failed", e)
+                phase = SelfUpdatePhase.Failed(info, e.message ?: "Download failed.")
+            }
+        }
+    }
+
+    LaunchedEffect(channel) {
+        phase = SelfUpdatePhase.Checking
+        val info = repository.checkForUpdate(channel)
+        if (info == null) {
+            phase = SelfUpdatePhase.UpToDate
+            return@LaunchedEffect
+        }
+
+        val staged = repository.alreadyStaged(info)
+        if (staged == null) {
+            phase = SelfUpdatePhase.Available(info, alreadyStaged = null)
+            if (autoDownload) startDownload(info)
+            return@LaunchedEffect
+        }
+
+        // A matching-size file is already sitting in the staging dir from a
+        // prior session — re-verify it (never trust "same size" alone)
+        // before offering to install it, falling back to a fresh download
+        // if it turns out to be a stale/corrupt leftover.
+        phase = SelfUpdatePhase.Verifying(info)
+        when (val result = repository.verify(staged, info)) {
+            is VerificationResult.Success -> {
+                phase = SelfUpdatePhase.Installing(info)
+                when (val launch = repository.launchInstaller(staged)) {
+                    is UpdateInstaller.LaunchResult.Success -> {
+                        onExitForInstall()
+                        exitProcess(0)
+                    }
+                    is UpdateInstaller.LaunchResult.Unsupported -> phase = SelfUpdatePhase.Failed(info, launch.reason)
+                    is UpdateInstaller.LaunchResult.Failure -> phase = SelfUpdatePhase.Failed(info, launch.reason)
+                }
+            }
+            else -> {
+                staged.delete()
+                phase = SelfUpdatePhase.Available(info, alreadyStaged = null)
+                if (autoDownload) startDownload(info)
+            }
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = {
+            downloadJob?.cancel()
+            onDismiss()
+        },
+        shape = RoundedCornerShape(corners.medium),
+        containerColor = MaterialTheme.colorScheme.surface,
+        title = {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(Icons.Default.NewReleases, contentDescription = null, tint = accents.secondary, modifier = Modifier.size(18.dp))
+                Text(
+                    text = "UPDATE MORPHE",
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = mono,
+                    fontSize = 13.sp,
+                    letterSpacing = 1.5.sp,
+                )
+            }
+        },
+        text = {
+            Box(modifier = Modifier.widthIn(min = 360.dp, max = 420.dp)) {
+                DialogBody(phase, mono, accents)
+            }
+        },
+        confirmButton = {
+            when (val p = phase) {
+                is SelfUpdatePhase.Available -> TextButton(onClick = { startDownload(p.info) }) {
+                    Icon(Icons.Default.Download, contentDescription = null, modifier = Modifier.size(16.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("DOWNLOAD & INSTALL", fontFamily = mono, fontSize = 11.sp, fontWeight = FontWeight.Bold)
+                }
+                is SelfUpdatePhase.Downloading -> TextButton(onClick = {
+                    downloadJob?.cancel()
+                    phase = SelfUpdatePhase.Available(p.info, alreadyStaged = null)
+                }) {
+                    Text("CANCEL", fontFamily = mono, fontSize = 11.sp, color = MaterialTheme.colorScheme.error)
+                }
+                is SelfUpdatePhase.Failed -> {
+                    Row {
+                        if (p.info != null) {
+                            TextButton(onClick = { startDownload(p.info) }) {
+                                Text("RETRY", fontFamily = mono, fontSize = 11.sp, fontWeight = FontWeight.Bold)
+                            }
+                        }
+                    }
+                }
+                else -> {}
+            }
+        },
+        dismissButton = {
+            val dismissable = phase !is SelfUpdatePhase.Downloading &&
+                phase !is SelfUpdatePhase.Verifying &&
+                phase !is SelfUpdatePhase.Installing
+            if (dismissable) {
+                TextButton(onClick = { downloadJob?.cancel(); onDismiss() }) {
+                    Text(
+                        text = if (phase is SelfUpdatePhase.Available) "LATER" else "CLOSE",
+                        fontFamily = mono,
+                        fontSize = 11.sp,
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun DialogBody(
+    phase: SelfUpdatePhase,
+    mono: androidx.compose.ui.text.font.FontFamily,
+    accents: app.morphe.gui.ui.theme.MorpheAccentColors,
+) {
+    when (phase) {
+        is SelfUpdatePhase.Checking -> LoadingRow("Checking for updates…", mono)
+        is SelfUpdatePhase.UpToDate -> LoadingRow("You're already on the latest version.", mono, icon = Icons.Default.CheckCircle)
+        is SelfUpdatePhase.Available -> ReleaseSummary(phase.info, mono, accents)
+        is SelfUpdatePhase.Downloading -> DownloadProgressView(phase.info, phase.progress, mono, accents)
+        is SelfUpdatePhase.Verifying -> LoadingRow("Verifying download…", mono)
+        is SelfUpdatePhase.Installing -> LoadingRow("Handing off to installer…", mono)
+        is SelfUpdatePhase.Failed -> Row(verticalAlignment = Alignment.Top, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Icon(Icons.Default.ErrorOutline, contentDescription = null, tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(18.dp))
+            Column {
+                Text("Update failed", fontFamily = mono, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+                Spacer(Modifier.height(4.dp))
+                Text(phase.message, fontFamily = mono, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingRow(text: String, mono: androidx.compose.ui.text.font.FontFamily, icon: androidx.compose.ui.graphics.vector.ImageVector? = null) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        if (icon != null) {
+            Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(18.dp))
+        } else {
+            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+        }
+        Text(text, fontFamily = mono, fontSize = 12.sp)
+    }
+}
+
+@Composable
+private fun ReleaseSummary(
+    info: UpdateReleaseInfo,
+    mono: androidx.compose.ui.text.font.FontFamily,
+    accents: app.morphe.gui.ui.theme.MorpheAccentColors,
+) {
+    Column {
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            LabeledValue("CURRENT", "v${info.currentVersion}", mono)
+            LabeledValue("LATEST", "v${info.latestVersion}", mono, accents.secondary)
+        }
+        Spacer(Modifier.height(6.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            LabeledValue("CHANNEL", info.channel.name, mono)
+            LabeledValue("SIZE", info.asset.getFormattedSize(), mono)
+            LabeledValue("PUBLISHED", formatPublishDate(info.release.publishedAt), mono)
+        }
+        val notes = info.release.body?.trim()
+        if (!notes.isNullOrBlank()) {
+            Spacer(Modifier.height(12.dp))
+            Text("RELEASE NOTES", fontFamily = mono, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.sp, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f))
+            Spacer(Modifier.height(4.dp))
+            SelectionContainer {
+                Box(
+                    modifier = Modifier
+                        .heightIn(max = 160.dp)
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                        .verticalScroll(rememberScrollState())
+                        .padding(10.dp),
+                ) {
+                    Text(
+                        text = notes.take(2000),
+                        fontFamily = mono,
+                        fontSize = 10.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LabeledValue(label: String, value: String, mono: androidx.compose.ui.text.font.FontFamily, color: androidx.compose.ui.graphics.Color = androidx.compose.ui.graphics.Color.Unspecified) {
+    Column {
+        Text(label, fontFamily = mono, fontSize = 9.sp, letterSpacing = 0.5.sp, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f))
+        Text(value, fontFamily = mono, fontSize = 12.sp, fontWeight = FontWeight.SemiBold, color = if (color == androidx.compose.ui.graphics.Color.Unspecified) MaterialTheme.colorScheme.onSurface else color)
+    }
+}
+
+@Composable
+private fun DownloadProgressView(
+    info: UpdateReleaseInfo,
+    progress: DownloadProgress?,
+    mono: androidx.compose.ui.text.font.FontFamily,
+    accents: app.morphe.gui.ui.theme.MorpheAccentColors,
+) {
+    Column {
+        Text("Downloading v${info.latestVersion}…", fontFamily = mono, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(10.dp))
+        val fraction = progress?.fraction
+        LinearProgressIndicator(
+            modifier = Modifier.fillMaxWidth().height(4.dp).clip(RoundedCornerShape(2.dp)),
+            color = accents.primary,
+            trackColor = accents.primary.copy(alpha = 0.12f),
+            progress = { fraction ?: 0f },
+        )
+        Spacer(Modifier.height(8.dp))
+        if (progress != null) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    text = buildString {
+                        append(formatBytes(progress.bytesRead))
+                        progress.totalBytes?.let { append(" / ${formatBytes(it)}") }
+                        fraction?.let { append("  ·  ${(it * 100).toInt()}%") }
+                    },
+                    fontFamily = mono,
+                    fontSize = 10.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = buildString {
+                        append(formatBytes(progress.bytesPerSecond) + "/s")
+                        progress.etaSeconds?.let { append("  ·  ${formatEta(it)} left") }
+                    },
+                    fontFamily = mono,
+                    fontSize = 10.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+private fun VerificationResult.describe(): String = when (this) {
+    is VerificationResult.Success -> "OK"
+    is VerificationResult.SizeMismatch -> "Downloaded file size ($actual bytes) didn't match the expected size ($expected bytes). The download may have been interrupted — try again."
+    is VerificationResult.CorruptArchive -> "The downloaded file is corrupted ($reason). Try downloading again."
+    is VerificationResult.ChecksumMismatch -> "Checksum did not match the published value. For safety, this update was not installed."
+    is VerificationResult.Error -> message
+}
+
+private fun formatBytes(bytes: Long): String = when {
+    bytes < 1024 -> "$bytes B"
+    bytes < 1024 * 1024 -> "%.1f KB".format(bytes / 1024.0)
+    else -> "%.1f MB".format(bytes / (1024.0 * 1024.0))
+}
+
+private fun formatEta(seconds: Long): String = when {
+    seconds < 60 -> "${seconds}s"
+    seconds < 3600 -> "${seconds / 60}m ${seconds % 60}s"
+    else -> "${seconds / 3600}h ${(seconds % 3600) / 60}m"
+}
+
+private val publishDateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy")
+
+private fun formatPublishDate(raw: String?): String {
+    if (raw.isNullOrBlank()) return "—"
+    return try {
+        OffsetDateTime.parse(raw).format(publishDateFormatter)
+    } catch (e: DateTimeParseException) {
+        raw
+    }
+}

--- a/src/main/kotlin/app/morphe/gui/ui/components/SettingsButton.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SettingsButton.kt
@@ -76,6 +76,7 @@ fun SettingsButton(
     var updateChannelPreference by remember { mutableStateOf(UpdateChannelPreference.STABLE) }
     var autoRouteLinksAfterInstall by remember { mutableStateOf(false) }
     var disableStockLinksAfterInstall by remember { mutableStateOf(false) }
+    var autoDownloadUpdates by remember { mutableStateOf(false) }
 
     LaunchedEffect(showSettingsDialog) {
         if (showSettingsDialog) {
@@ -93,6 +94,7 @@ fun SettingsButton(
             collapsibleSectionStates = config.collapsibleSectionStates
             autoRouteLinksAfterInstall = config.autoRouteLinksAfterInstall
             disableStockLinksAfterInstall = config.disableStockLinksAfterInstall
+            autoDownloadUpdates = config.autoDownloadUpdates
             // Resolve the smart-default if the user has never picked a channel
             // (returns DEV when the running build is dev, STABLE otherwise).
             updateChannelPreference = configRepository.getOrInitUpdateChannelPreference(
@@ -204,6 +206,11 @@ fun SettingsButton(
             onDisableStockLinksChange = { enabled ->
                 disableStockLinksAfterInstall = enabled
                 scope.launch { configRepository.setDisableStockLinksAfterInstall(enabled) }
+            },
+            autoDownloadUpdates = autoDownloadUpdates,
+            onAutoDownloadUpdatesChange = { enabled ->
+                autoDownloadUpdates = enabled
+                scope.launch { configRepository.setAutoDownloadUpdates(enabled) }
             },
             collapsibleSectionStates = collapsibleSectionStates,
             onCollapsibleSectionToggle = { id, expanded ->

--- a/src/main/kotlin/app/morphe/gui/ui/components/SettingsDialog.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SettingsDialog.kt
@@ -89,6 +89,8 @@ fun SettingsDialog(
     onKeepArchitecturesChange: (Set<String>) -> Unit = {},
     updateChannelPreference: app.morphe.gui.data.model.UpdateChannelPreference = app.morphe.gui.data.model.UpdateChannelPreference.STABLE,
     onUpdateChannelChange: (app.morphe.gui.data.model.UpdateChannelPreference) -> Unit = {},
+    autoDownloadUpdates: Boolean = false,
+    onAutoDownloadUpdatesChange: (Boolean) -> Unit = {},
     autoStartAdb: Boolean = false,
     onAutoStartAdbChange: (Boolean) -> Unit = {},
     autoRouteLinksAfterInstall: Boolean = false,
@@ -215,6 +217,16 @@ fun SettingsDialog(
                     mono = mono,
                     borderColor = borderColor,
                     enabled = !isPatching,
+                )
+
+                SettingToggleRow(
+                    label = "Auto-download updates",
+                    description = "Fetch new versions in the background as soon as they're found — installing still requires a click",
+                    checked = autoDownloadUpdates,
+                    onCheckedChange = onAutoDownloadUpdatesChange,
+                    accentColor = accents.primary,
+                    mono = mono,
+                    enabled = !isPatching && updateChannelPreference != app.morphe.gui.data.model.UpdateChannelPreference.OFF,
                 )
 
                 SettingsDivider(borderColor)

--- a/src/main/kotlin/app/morphe/gui/ui/components/UpdateBanner.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/UpdateBanner.kt
@@ -44,7 +44,10 @@ import app.morphe.gui.ui.theme.LocalMorpheFont
  * Non-blocking banner shown when a newer CLI release is available.
  *
  * Three actions:
- *  - DOWNLOAD opens the release page in the user's browser.
+ *  - DOWNLOAD opens [onDownloadClick] — the self-update dialog, which
+ *    downloads and installs the update in-app. Falls back to opening the
+ *    release page in the browser when [onDownloadClick] isn't supplied
+ *    (e.g. self-update being unavailable for this build).
  *  - LATER hides the banner for the rest of the session (returns next startup).
  *  - SKIP v{latestVersion} hides the banner persistently for this version
  *    only — reappears when an even newer version drops.
@@ -55,6 +58,7 @@ fun UpdateBanner(
     onDismissForSession: () -> Unit,
     onDismissForVersion: () -> Unit,
     modifier: Modifier = Modifier,
+    onDownloadClick: (() -> Unit)? = null,
 ) {
     val corners = LocalMorpheCorners.current
     val mono = LocalMorpheFont.current
@@ -107,7 +111,7 @@ fun UpdateBanner(
             val downloadHover = remember { MutableInteractionSource() }
             val isDownloadHovered by downloadHover.collectIsHoveredAsState()
             OutlinedButton(
-                onClick = { uriHandler.openUri(info.downloadLink) },
+                onClick = { onDownloadClick?.invoke() ?: uriHandler.openUri(info.downloadLink) },
                 modifier = Modifier.hoverable(downloadHover).height(24.dp),
                 shape = RoundedCornerShape(corners.small),
                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),

--- a/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeScreen.kt
@@ -131,6 +131,33 @@ fun HomeScreenContent(
     // away) shows stale "NOT ON THIS DEVICE" until the next full reload.
     LaunchedEffect(Unit) { viewModel.refreshDeviceInfo() }
 
+    // ── Self-update dialog (in-app download/verify/install) ──
+    // Opened from UpdateBanner's DOWNLOAD action. The dialog does its own rich
+    // release check via SelfUpdateRepository — this just supplies which channel
+    // to check and whether to auto-start the download once it finds one.
+    val selfUpdateRepository: app.morphe.gui.data.repository.SelfUpdateRepository = org.koin.compose.koinInject()
+    val configRepositoryForUpdate: app.morphe.gui.data.repository.ConfigRepository = org.koin.compose.koinInject()
+    var showSelfUpdateDialog by remember { mutableStateOf(false) }
+    var selfUpdateChannel by remember { mutableStateOf(app.morphe.gui.data.model.UpdateChannelPreference.STABLE) }
+    var autoDownloadUpdates by remember { mutableStateOf(false) }
+    val selfUpdateScope = rememberCoroutineScope()
+    val openSelfUpdateDialog: () -> Unit = {
+        selfUpdateScope.launch {
+            val config = configRepositoryForUpdate.loadConfig()
+            selfUpdateChannel = config.getUpdateChannelPreference() ?: app.morphe.gui.data.model.UpdateChannelPreference.STABLE
+            autoDownloadUpdates = config.autoDownloadUpdates
+            showSelfUpdateDialog = true
+        }
+    }
+    if (showSelfUpdateDialog) {
+        app.morphe.gui.ui.components.SelfUpdateDialog(
+            channel = selfUpdateChannel,
+            autoDownload = autoDownloadUpdates,
+            repository = selfUpdateRepository,
+            onDismiss = { showSelfUpdateDialog = false },
+        )
+    }
+
     // One-click repatch: a patched-app row's "Re-patch" action. Jump straight to
     // patch selection with the input APK + the record's saved selection, using
     // the CURRENT resolved sources (so it repatches against current bundle versions).
@@ -605,6 +632,7 @@ fun HomeScreenContent(
                                     info = uiState.updateInfo!!,
                                     onDismissForSession = { viewModel.dismissUpdateForSession() },
                                     onDismissForVersion = { viewModel.dismissUpdateForVersion() },
+                                    onDownloadClick = openSelfUpdateDialog,
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .padding(start = padding, end = padding, top = 8.dp),


### PR DESCRIPTION
This PR adds a built-in self-updater for Morphe Desktop.

Morphe Desktop already notifies users when a new version is available. This PR extend that feature by allowing users to download and install updates directly from within the application, eliminating the need to manually download and replace the JAR.

The update implementation is shared between the GUI and CLI, so both interfaces use the same update pipeline, verification logic, and installation process.

## this is how it works

When Morphe Desktop detects that a newer version is available, the existing update banner is displayed as before.

When the user clicks **Download**, a new update dialog opens and displays the download progress of the latest Morphe Desktop release and its changelog.

After the download completes:

- Morphe Desktop closes automatically
- the existing JAR is replaced with the newly downloaded version
- Morphe Desktop is relaunched automatically

The update process is designed to be seamless, requiring no manual intervention from the user.

i have tested it successfully on the latest main/dev branch.