### PR TITLE
fix: Resilient patch bundle loading + quieter ADB logging + unique version output naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.13.0-dev.6](https://github.com/MorpheApp/morphe-desktop/compare/v1.13.0-dev.5...v1.13.0-dev.6) (2026-08-02)
+
+
+### Features
+
+* developer mode +  configurable data directory ([#220](https://github.com/MorpheApp/morphe-desktop/issues/220)) ([a1ba3a2](https://github.com/MorpheApp/morphe-desktop/commit/a1ba3a2f7e4d2793c0371fc77df2241bc8c828da))
+
 # [1.13.0-dev.5](https://github.com/MorpheApp/morphe-desktop/compare/v1.13.0-dev.4...v1.13.0-dev.5) (2026-08-02)
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,7 +157,12 @@ tasks {
 
         // Only expand properties files, not binary files like PNG/ICO
         filesMatching("**/*.properties") {
-            expand("projectVersion" to project.version)
+            expand(
+                "projectVersion" to project.version,
+                // The bundled patcher version, so the app can tell a user when a
+                // patch bundle needs a newer patcher than this build ships.
+                "patcherVersion" to libs.versions.morphe.patcher.get(),
+            )
         }
         // Bundle the project's NOTICE (GPL 7b/7c) and LICENSE into META-INF so they
         // land in the main JAR before the Shadow merge. Source of truth stays at the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,18 +150,45 @@ tasks {
         }
     }
 
+    // Write the *resolved* morphe library version (not the catalog pin). Patcher ships
+    // its own version.properties.
+    val writeMorpheComponents = register("writeMorpheComponents") {
+        description = "Writes the resolved morphe-library version to components.properties"
+        val outFile = layout.buildDirectory.file(
+            "generated/morphe-components/app/morphe/cli/components.properties",
+        )
+        val runtimeCp = configurations.named("runtimeClasspath")
+        inputs.files(runtimeCp)
+        outputs.file(outFile)
+        doLast {
+            val libraryVersion = runtimeCp.get().incoming.resolutionResult.allComponents
+                .mapNotNull { it.moduleVersion }
+                .firstOrNull { it.group == "app.morphe" && it.name.startsWith("morphe-library") }
+                ?.version
+                ?: "unknown"
+            outFile.get().asFile.apply {
+                parentFile.mkdirs()
+                writeText(
+                    "# Generated from resolved runtimeClasspath — do not edit\n" +
+                        "libraryVersion=$libraryVersion\n",
+                )
+            }
+        }
+    }
+
     processResources {
         // Make sure the licenses are generated before the resources are processed
-        dependsOn("exportLibraryDefinitions")
+        dependsOn("exportLibraryDefinitions", writeMorpheComponents)
         from(layout.buildDirectory.file("generated/aboutLibraries/aboutlibraries.json"))
+        from(layout.buildDirectory.dir("generated/morphe-components"))
 
-        // Only expand properties files, not binary files like PNG/ICO
+        // Only expand properties files, not binary files like PNG/ICO.
+        // Patcher is read from its jar at runtime. libraryVersion lives in
+        // components.properties generated above, skip token expansion for it.
         filesMatching("**/*.properties") {
+            if (path.contains("components.properties")) return@filesMatching
             expand(
                 "projectVersion" to project.version,
-                // The bundled patcher version, so the app can tell a user when a
-                // patch bundle needs a newer patcher than this build ships.
-                "patcherVersion" to libs.versions.morphe.patcher.get(),
             )
         }
         // Bundle the project's NOTICE (GPL 7b/7c) and LICENSE into META-INF so they

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.parallel = true
 org.gradle.caching = true
 kotlin.code.style = official
-version = 1.13.0-dev.5
+version = 1.13.0-dev.6
 # Compose Desktop (5 OS targets) + Kotlin/Compose codegen need a bit more heap than
 # the Gradle/Kotlin defaults (which intermittently OOM with "GC overhead limit
 # exceeded" during codegen), but not so much it swaps alongside the IDE. 2g each

--- a/src/main/kotlin/app/morphe/engine/MorpheComponents.kt
+++ b/src/main/kotlin/app/morphe/engine/MorpheComponents.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine
+
+import java.util.Properties
+
+/**
+ * Versions of Morphe ecosystem components that this desktop build is running against.
+ *
+ * Prefer each library's own embedded resource when present (so composite/local
+ * substitutions report the truth). Fall back to build-time resolved metadata only
+ * when a library does not ship a version resource (currently: morphe-library).
+ */
+object MorpheComponents {
+
+    /** morphe-patcher on the classpath (`app/morphe/patcher/version.properties`). */
+    val patcherVersion: String? by lazy {
+        readVersionProperty("/app/morphe/patcher/version.properties", "version")
+    }
+
+    /**
+     * morphe-library on the classpath.
+     * Prefers `app/morphe/library/version.properties` if the library starts shipping it;
+     * otherwise the build-time resolved version in `app/morphe/cli/components.properties`.
+     */
+    val libraryVersion: String? by lazy {
+        readVersionProperty("/app/morphe/library/version.properties", "version")
+            ?: readVersionProperty("/app/morphe/cli/components.properties", "libraryVersion")
+    }
+
+    private fun readVersionProperty(resourcePath: String, key: String): String? =
+        runCatching {
+            MorpheComponents::class.java
+                .getResourceAsStream(resourcePath)
+                ?.use { Properties().apply { load(it) }.getProperty(key) }
+                ?.trim()
+                ?.takeUnless { it.isEmpty() || it.startsWith("\${") }
+        }.getOrNull()
+}

--- a/src/main/kotlin/app/morphe/engine/MultiSourceLoader.kt
+++ b/src/main/kotlin/app/morphe/engine/MultiSourceLoader.kt
@@ -94,13 +94,20 @@ object MultiSourceLoader {
                 sourceName = input.sourceName,
                 patches = patches,
             )
-        } catch (e: Exception) {
-            logger.warning("MultiSourceLoader: failed to load '${input.sourceName}': ${e.message}")
+        } catch (e: Throwable) {
+            // Catch Throwable, not just Exception: a bundle built against a newer patcher
+            // throws java.lang.Error (NoSuchMethodError / NoClassDefFoundError / LinkageError)
+            // because it references patcher APIs missing here. As an Error it would escape a
+            // catch(Exception), sink the whole load, and hang the UI on "loading" forever.
+            // Isolating it per source keeps one bad bundle from taking the others down, and
+            // lets us surface a clear "update Morphe" message (mirrors morphe-manager).
+            val versionMsg = PatcherCompatibility.incompatibilityMessage(input.patchFile)
+            logger.warning("MultiSourceLoader: failed to load '${input.sourceName}': ${versionMsg ?: e.message}")
             LoadedSource(
                 sourceId = input.sourceId,
                 sourceName = input.sourceName,
                 patches = emptySet(),
-                error = e,
+                error = versionMsg?.let { PatchBundleIncompatibleException(it) } ?: e,
             )
         } finally {
             tempCopy.deleteOnExit()

--- a/src/main/kotlin/app/morphe/engine/MultiSourceLoader.kt
+++ b/src/main/kotlin/app/morphe/engine/MultiSourceLoader.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
@@ -101,13 +102,29 @@ object MultiSourceLoader {
             // catch(Exception), sink the whole load, and hang the UI on "loading" forever.
             // Isolating it per source keeps one bad bundle from taking the others down, and
             // lets us surface a clear "update Morphe" message (mirrors morphe-manager).
+            //
+            // Do NOT swallow the real failure: many Errors have a null .message (e.g.
+            // ExceptionInInitializerError) with the useful text on .cause. We always store an
+            // exception whose message walks the full cause chain, and log the full stack.
             val versionMsg = PatcherCompatibility.incompatibilityMessage(input.patchFile)
-            logger.warning("MultiSourceLoader: failed to load '${input.sourceName}': ${versionMsg ?: e.message}")
+            val error: Throwable = if (versionMsg != null) {
+                PatchBundleIncompatibleException(versionMsg)
+            } else {
+                PatchSourceLoadException(e.readableMessage(), e)
+            }
+            logger.log(
+                Level.WARNING,
+                "MultiSourceLoader: failed to load '${input.sourceName}': ${error.message}",
+                e,
+            )
+            // Also stderr so IDE runs / headless CLI see the stack even if JUL is unconfigured.
+            System.err.println("MultiSourceLoader: failed to load '${input.sourceName}': ${error.message}")
+            e.printStackTrace(System.err)
             LoadedSource(
                 sourceId = input.sourceId,
                 sourceName = input.sourceName,
                 patches = emptySet(),
-                error = versionMsg?.let { PatchBundleIncompatibleException(it) } ?: e,
+                error = error,
             )
         } finally {
             tempCopy.deleteOnExit()

--- a/src/main/kotlin/app/morphe/engine/PatcherCompatibility.kt
+++ b/src/main/kotlin/app/morphe/engine/PatcherCompatibility.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine
+
+import java.io.File
+import java.util.Properties
+import java.util.zip.ZipInputStream
+import java.util.logging.Logger
+
+/**
+ * Detects when a patch bundle (.mpp) was built against a newer morphe-patcher than this
+ * build ships. Such a bundle fails to load with a `java.lang.Error` (NoSuchMethodError,
+ * NoClassDefFoundError, LinkageError) because it references patcher APIs that do not exist
+ * here, which otherwise surfaces as a cryptic failure. This turns it into a clear "update
+ * Morphe" message, mirroring how morphe-manager reads the bundle's `Patcher-Version`
+ * manifest attribute and compares it to the patcher it ships.
+ *
+ * Deliberately lenient: any doubt (missing attribute, unparseable version, unreadable file)
+ * returns null so a valid bundle is never wrongly rejected.
+ */
+object PatcherCompatibility {
+
+    private val logger = Logger.getLogger(PatcherCompatibility::class.java.name)
+
+    /** The morphe-patcher version this build ships, from the generated version.properties. */
+    val currentPatcherVersion: String? by lazy {
+        runCatching {
+            PatcherCompatibility::class.java
+                .getResourceAsStream("/app/morphe/cli/version.properties")
+                ?.use { Properties().apply { load(it) }.getProperty("patcherVersion") }
+                ?.trim()
+                ?.takeUnless { it.isEmpty() || it.startsWith("\${") }
+        }.getOrNull()
+    }
+
+    /**
+     * The morphe-patcher version [mpp] requires, from its `Patcher-Version` manifest
+     * attribute. Null when the bundle predates that attribute or can't be read.
+     */
+    fun requiredPatcherVersion(mpp: File): String? = runCatching {
+        mpp.inputStream().use { fis ->
+            ZipInputStream(fis).use { zip ->
+                var entry = zip.nextEntry
+                while (entry != null) {
+                    if (entry.name == "META-INF/MANIFEST.MF") {
+                        return@runCatching manifestAttr(zip.bufferedReader().readText(), "Patcher-Version")
+                    }
+                    entry = zip.nextEntry
+                }
+                null
+            }
+        }
+    }.getOrNull()
+
+    /**
+     * A user-facing explanation when [mpp] needs a newer patcher than this build ships, or
+     * null when compatible / unknown (never blocks on doubt).
+     */
+    fun incompatibilityMessage(mpp: File): String? {
+        val required = requiredPatcherVersion(mpp) ?: return null
+        val current = currentPatcherVersion ?: return null
+        if (!isNewer(required, current)) return null
+        logger.info("Bundle ${mpp.name} needs patcher $required, this build ships $current")
+        return "This patch bundle needs Morphe patcher $required, but this build ships $current. " +
+            "Update Morphe to use it."
+    }
+
+    private fun manifestAttr(manifest: String, key: String): String? =
+        manifest.lineSequence()
+            .firstOrNull { it.substringBefore(':', "").trim().equals(key, ignoreCase = true) }
+            ?.substringAfter(':')?.trim()
+            ?.takeUnless { it.isBlank() || it.equals("na", ignoreCase = true) }
+
+    /** True when version [a] is newer than [b]. Compares numeric components, ignores pre-release. */
+    private fun isNewer(a: String, b: String): Boolean {
+        val pa = numericParts(a)
+        val pb = numericParts(b)
+        for (i in 0 until maxOf(pa.size, pb.size)) {
+            val x = pa.getOrElse(i) { 0 }
+            val y = pb.getOrElse(i) { 0 }
+            if (x != y) return x > y
+        }
+        return false
+    }
+
+    private fun numericParts(v: String): List<Int> =
+        v.substringBefore('-').split('.').map { it.trim().toIntOrNull() ?: 0 }
+}
+
+/**
+ * A patch bundle that could not be loaded because it needs a newer patcher than this build
+ * ships. Its [message] is already user-facing (from [PatcherCompatibility.incompatibilityMessage]).
+ */
+class PatchBundleIncompatibleException(message: String) : Exception(message)

--- a/src/main/kotlin/app/morphe/engine/PatcherCompatibility.kt
+++ b/src/main/kotlin/app/morphe/engine/PatcherCompatibility.kt
@@ -6,7 +6,6 @@
 package app.morphe.engine
 
 import java.io.File
-import java.util.Properties
 import java.util.zip.ZipInputStream
 import java.util.logging.Logger
 
@@ -18,6 +17,11 @@ import java.util.logging.Logger
  * Morphe" message, mirroring how morphe-manager reads the bundle's `Patcher-Version`
  * manifest attribute and compares it to the patcher it ships.
  *
+ * The "ships" version is read from the **patcher library on the classpath**
+ * (`app/morphe/patcher/version.properties`), not from the desktop app's version catalog.
+ * That way a composite/local `morphe-patcher` (or any resolved artifact) reports its own
+ * version instead of a stale catalog pin in `libs.versions.toml`.
+ *
  * Deliberately lenient: any doubt (missing attribute, unparseable version, unreadable file)
  * returns null so a valid bundle is never wrongly rejected.
  */
@@ -25,16 +29,10 @@ object PatcherCompatibility {
 
     private val logger = Logger.getLogger(PatcherCompatibility::class.java.name)
 
-    /** The morphe-patcher version this build ships, from the generated version.properties. */
-    val currentPatcherVersion: String? by lazy {
-        runCatching {
-            PatcherCompatibility::class.java
-                .getResourceAsStream("/app/morphe/cli/version.properties")
-                ?.use { Properties().apply { load(it) }.getProperty("patcherVersion") }
-                ?.trim()
-                ?.takeUnless { it.isEmpty() || it.startsWith("\${") }
-        }.getOrNull()
-    }
+    /**
+     * The morphe-patcher version on the classpath (see [MorpheComponents.patcherVersion]).
+     */
+    val currentPatcherVersion: String? get() = MorpheComponents.patcherVersion
 
     /**
      * The morphe-patcher version [mpp] requires, from its `Patcher-Version` manifest

--- a/src/main/kotlin/app/morphe/engine/ThrowableMessages.kt
+++ b/src/main/kotlin/app/morphe/engine/ThrowableMessages.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine
+
+import java.io.PrintWriter
+import java.io.StringWriter
+
+/**
+ * Helpers for turning throwables into something a human (or log file) can actually use.
+ *
+ * Many JVM errors, notably [ExceptionInInitializerError] have a **null** [Throwable.message]
+ * and bury the real explanation on [Throwable.cause]. Call sites that only read `.message`
+ * then surface useless copy like "Failed to load".
+ */
+
+/**
+ * Quick description of this throwable and its cause chain.
+ *
+ * Example:
+ * `ExceptionInInitializerError:
+ * Cause by: UninitializedPropertyAccessException: lateinit property x has not been initialized`
+ */
+fun Throwable.readableMessage(): String {
+    val chain = generateSequence(this) { it.cause }.toList()
+    val parts = chain.map { t ->
+        val msg = t.message?.trim()?.takeIf { it.isNotEmpty() }
+        if (msg != null) "${t.javaClass.simpleName}: $msg" else t.javaClass.simpleName
+    }
+    // Drop pure type-only prefixes once we hit a frame that has a message, but keep the
+    // whole chain so nested init/reflection failures stay diagnosable.
+    return parts.joinToString("\nCaused by: ").ifBlank { javaClass.name }
+}
+
+/** Full stack trace as a string (for file / stderr logging). */
+fun Throwable.stackTraceString(): String {
+    val sw = StringWriter()
+    printStackTrace(PrintWriter(sw))
+    return sw.toString()
+}
+
+/**
+ * Load failure for one patch source. Always carries a non-blank [message] so UI layers
+ * never fall back to generic "Failed to load". The original throwable is [cause].
+ */
+class PatchSourceLoadException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/src/main/kotlin/app/morphe/engine/util/ApkOutputNaming.kt
+++ b/src/main/kotlin/app/morphe/engine/util/ApkOutputNaming.kt
@@ -68,6 +68,15 @@ object ApkOutputNaming {
         ApkManifestReader.read(apkFile)?.applicationLabel?.takeIf { it.isNotBlank() }
 
     /**
+     * The app's versionName from its manifest (engine [ApkManifestReader]), or null when it
+     * can't be read or is blank. The reliable source of the app version, unlike
+     * [extractApkVersionFromFilename], which only works when the input file follows the
+     * APKMirror naming convention.
+     */
+    fun resolveAppVersion(apkFile: File): String? =
+        ApkManifestReader.read(apkFile)?.versionName?.takeIf { it.isNotBlank() }
+
+    /**
      * Compute the unified output APK path. Layout:
      * `<base>/<appName>/<appName>-Morphe-{apkVer}-patches-{patchesVer}.apk`
      *
@@ -94,6 +103,7 @@ object ApkOutputNaming {
         patchesFile: File? = null,
         baseOutputDir: File? = null,
         appDisplayName: String? = null,
+        appVersion: String? = null,
     ): File {
         val appFolderName = (appDisplayName ?: inputApk.nameWithoutExtension)
             .replace(" ", "-")
@@ -101,9 +111,26 @@ object ApkOutputNaming {
             ?: inputApk.absoluteFile.parentFile
             ?: File("").absoluteFile
         val outputDir = File(base, appFolderName).also { it.mkdirs() }
-        val version = extractApkVersionFromFilename(inputApk.name) ?: "patched"
+        // App version, most reliable first: a version the caller already resolved, then the
+        // APK manifest's versionName, then the input filename (APKMirror convention), then a
+        // constant. Reading it from the manifest is what keeps the output unique by app
+        // version even when the input file was renamed (e.g. base.apk) — the filename-only
+        // path fell back to "patched" and collided across versions.
+        val version = sanitizeForFilename(
+            appVersion?.takeIf { it.isUsableVersion() }
+                ?: resolveAppVersion(inputApk)
+                ?: extractApkVersionFromFilename(inputApk.name)
+                ?: "patched"
+        )
         val patchesVersion = patchesFile?.name?.let { extractPatchesVersion(it) }
         val patchesSuffix = if (patchesVersion != null) "-patches-$patchesVersion" else ""
         return File(outputDir, "${appFolderName}-Morphe-${version}${patchesSuffix}.apk")
     }
+
+    private fun String.isUsableVersion(): Boolean =
+        isNotBlank() && !equals("unknown", ignoreCase = true)
+
+    /** Keep a versionName filename-safe: some apps put spaces or symbols in versionName. */
+    private fun sanitizeForFilename(v: String): String =
+        v.trim().replace(Regex("""[^A-Za-z0-9.\-_]"""), "-").ifBlank { "patched" }
 }

--- a/src/main/kotlin/app/morphe/gui/di/AppModule.kt
+++ b/src/main/kotlin/app/morphe/gui/di/AppModule.kt
@@ -110,6 +110,7 @@ val appModule = module {
             params.get(),
             params.get(),
             params.get(),
+            params.get(),
         )
     }
     factory { params ->

--- a/src/main/kotlin/app/morphe/gui/ui/components/SourceManagementSheet.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SourceManagementSheet.kt
@@ -96,6 +96,9 @@ fun SourceManagementSheet(
      *  in place of the version/badge for enabled sources whose data isn't yet
      *  in [sourceVersions]. */
     isLoading: Boolean = false,
+    /** sourceId → load-failure message for sources that failed to load. Drives the per-row
+     *  FAILED state, so a partial multi-source failure shows exactly which source broke. */
+    sourceErrors: Map<String, String> = emptyMap(),
     /** Selection semantics. Defaults to multi-toggle (Expert mode). */
     mode: SourceSheetMode = SourceSheetMode.MULTI_TOGGLE,
     /** sourceId of the currently picked source — only used when [mode] is SINGLE_SELECT. */
@@ -235,6 +238,7 @@ fun SourceManagementSheet(
                         version = sourceVersions[source.id],
                         channel = sourceChannels[source.id],
                         isLoading = isLoading,
+                        error = sourceErrors[source.id],
                         accentColor = accents.primary,
                         borderColor = borderColor,
                         mono = mono,
@@ -342,6 +346,7 @@ private fun SourceRow(
     version: String?,
     channel: app.morphe.gui.util.EnabledSourcesLoader.Channel?,
     isLoading: Boolean,
+    error: String? = null,
     accentColor: Color,
     borderColor: Color,
     mono: androidx.compose.ui.text.font.FontFamily,
@@ -376,6 +381,13 @@ private fun SourceRow(
     // For visual highlight: in MULTI mode highlight when source is enabled; in
     // SINGLE_SELECT highlight when this row is the picked one.
     val isHighlighted = if (mode == SourceSheetMode.SINGLE_SELECT) isActiveSelection else isEnabled
+
+    // The status LED reflects the source's state: red on load failure, otherwise its
+    // release-channel color (green stable-latest, amber stable-older, blue dev-latest,
+    // red dev-older, plus the local tint). Same color source as the home pill LEDs, so
+    // the two always agree. While resolving, channelColor's UNKNOWN default applies.
+    val statusColor = if (error != null) MaterialTheme.colorScheme.error
+                      else app.morphe.gui.ui.theme.channelColor(channel)
 
     val animatedBorder by animateColorAsState(
         targetValue = when {
@@ -445,7 +457,7 @@ private fun SourceRow(
                 )
             }
             // LED indicator — glows when enabled (MULTI) or selected (SINGLE).
-            LedIndicator(isOn = isHighlighted, isHot = isHovered && canInteract, accentColor = accentColor)
+            LedIndicator(isOn = isHighlighted, isHot = isHovered && canInteract, accentColor = statusColor)
             Spacer(Modifier.width(10.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
@@ -454,8 +466,12 @@ private fun SourceRow(
                         fontSize = 12.sp,
                         fontWeight = if (isEnabled) FontWeight.SemiBold else FontWeight.Normal,
                         color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        // Wrap to a second line instead of cramming/ellipsizing a long name
+                        // against the DEFAULT badge. weight(fill = false) bounds the width so
+                        // it wraps within the row rather than pushing the badge off.
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
                     )
                     if (isDefault) {
                         Text(
@@ -486,7 +502,22 @@ private fun SourceRow(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f, fill = false)
                     )
-                    if (isEnabled && version != null) {
+                    if (error != null) {
+                        Text(
+                            text = "·",
+                            fontSize = 10.sp,
+                            fontFamily = mono,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+                        )
+                        Text(
+                            text = "FAILED",
+                            fontSize = 9.sp,
+                            fontFamily = mono,
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 1.sp,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    } else if (isEnabled && version != null) {
                         Text(
                             text = "·",
                             fontSize = 10.sp,
@@ -523,6 +554,18 @@ private fun SourceRow(
                             letterSpacing = 1.sp,
                         )
                     }
+                }
+                if (error != null) {
+                    Spacer(Modifier.height(3.dp))
+                    Text(
+                        text = error,
+                        fontSize = 9.sp,
+                        fontFamily = mono,
+                        lineHeight = 12.sp,
+                        color = MaterialTheme.colorScheme.error.copy(alpha = 0.85f),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
             }
 
@@ -647,6 +690,7 @@ private fun ChannelBadge(
         app.morphe.gui.util.EnabledSourcesLoader.Channel.STABLE_OLDER -> "STABLE OLDER"
         app.morphe.gui.util.EnabledSourcesLoader.Channel.DEV_LATEST -> "DEV LATEST"
         app.morphe.gui.util.EnabledSourcesLoader.Channel.DEV_OLDER -> "DEV OLDER"
+        app.morphe.gui.util.EnabledSourcesLoader.Channel.LOCAL -> "LOCAL"
         else -> "STABLE LATEST"
     }
     val color = app.morphe.gui.ui.theme.channelColor(channel)

--- a/src/main/kotlin/app/morphe/gui/ui/components/SourcesPill.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SourcesPill.kt
@@ -38,7 +38,7 @@ import app.morphe.gui.ui.theme.LocalMorpheFont
 import app.morphe.gui.util.EnabledSourcesLoader
 
 /** Per-source LED state surfaced in [SourcesCountPill]. */
-enum class SourceLedState { DISABLED, STABLE_LATEST, STABLE_OLDER, DEV_LATEST, DEV_OLDER }
+enum class SourceLedState { DISABLED, STABLE_LATEST, STABLE_OLDER, DEV_LATEST, DEV_OLDER, LOCAL, ERROR }
 
 /**
  * Header pill showing source count + per-source channel LEDs + trailing "+".
@@ -118,6 +118,8 @@ private fun SourceLed(state: SourceLedState) {
         SourceLedState.STABLE_OLDER -> app.morphe.gui.ui.theme.channelColor(EnabledSourcesLoader.Channel.STABLE_OLDER)
         SourceLedState.DEV_LATEST -> app.morphe.gui.ui.theme.channelColor(EnabledSourcesLoader.Channel.DEV_LATEST)
         SourceLedState.DEV_OLDER -> app.morphe.gui.ui.theme.channelColor(EnabledSourcesLoader.Channel.DEV_OLDER)
+        SourceLedState.LOCAL -> app.morphe.gui.ui.theme.channelColor(EnabledSourcesLoader.Channel.LOCAL)
+        SourceLedState.ERROR -> MaterialTheme.colorScheme.error
     }
     Box(
         modifier = Modifier
@@ -130,13 +132,18 @@ private fun SourceLed(state: SourceLedState) {
 fun sourceLedState(
     source: PatchSource,
     channel: EnabledSourcesLoader.Channel?,
+    hasError: Boolean = false,
 ): SourceLedState {
     if (!source.enabled) return SourceLedState.DISABLED
+    // Error wins over channel: a source that resolved (so it still carries a channel, e.g.
+    // LOCAL) but failed to load should read red, not its channel color.
+    if (hasError) return SourceLedState.ERROR
     return when (channel) {
         EnabledSourcesLoader.Channel.STABLE_LATEST -> SourceLedState.STABLE_LATEST
         EnabledSourcesLoader.Channel.STABLE_OLDER -> SourceLedState.STABLE_OLDER
         EnabledSourcesLoader.Channel.DEV_LATEST -> SourceLedState.DEV_LATEST
         EnabledSourcesLoader.Channel.DEV_OLDER -> SourceLedState.DEV_OLDER
+        EnabledSourcesLoader.Channel.LOCAL -> SourceLedState.LOCAL
         // No load yet — assume latest until we know otherwise.
         null, EnabledSourcesLoader.Channel.UNKNOWN -> SourceLedState.STABLE_LATEST
     }

--- a/src/main/kotlin/app/morphe/gui/ui/components/ToolsDialog.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/ToolsDialog.kt
@@ -20,11 +20,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.morphe.engine.CacheManager
+import app.morphe.engine.MorpheComponents
 import app.morphe.gui.data.constants.AppConstants
 import app.morphe.gui.ui.theme.LocalMorpheCorners
 import app.morphe.gui.ui.theme.LocalMorpheFont
 import app.morphe.gui.ui.theme.MorpheColors
-import app.morphe.engine.CacheManager
 import app.morphe.gui.util.FileUtils
 import app.morphe.gui.util.Logger
 import java.awt.Desktop
@@ -155,12 +156,25 @@ fun ToolsDialog(
 
                 Spacer(Modifier.height(14.dp))
 
-                // ── About ──
+                // ── About (Morphe ecosystem versions) ──
+                val aboutColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
                 Text(
                     text = "${AppConstants.APP_NAME} ${AppConstants.APP_VERSION}",
                     fontSize = 10.sp,
                     fontFamily = mono,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                    color = aboutColor,
+                )
+                Text(
+                    text = "Morphe Patcher ${MorpheComponents.patcherVersion ?: "unknown"}",
+                    fontSize = 10.sp,
+                    fontFamily = mono,
+                    color = aboutColor,
+                )
+                Text(
+                    text = "Morphe Library ${MorpheComponents.libraryVersion ?: "unknown"}",
+                    fontSize = 10.sp,
+                    fontFamily = mono,
+                    color = aboutColor,
                 )
             }
         },

--- a/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeScreen.kt
@@ -426,10 +426,19 @@ fun HomeScreenContent(
             ?.resolved
             ?.associate { it.source.id to it.channel }
             ?: emptyMap()
+        // Per-source load failures (resolve phase + load phase), so the sheet shows which
+        // source broke and why. Same data the "some sources failed" banner is driven by.
+        val sourceErrors: Map<String, String> = buildMap {
+            snapshot?.resolved?.forEach { r -> r.error?.let { put(r.source.id, it) } }
+            snapshot?.loaded?.perSource?.forEach { s ->
+                if (!s.isSuccess) put(s.sourceId, s.error?.message ?: "Failed to load")
+            }
+        }
         SourceManagementSheet(
             sources = allSources,
             sourceVersions = versions,
             sourceChannels = channels,
+            sourceErrors = sourceErrors,
             isLoading = uiState.isLoadingPatches,
             onToggleEnabled = { id, enabled ->
                 coroutineScope.launch {
@@ -511,6 +520,7 @@ fun HomeScreenContent(
                                 patchesFilePath = patchesFile.absolutePath,
                                 packageName = uiState.apkInfo!!.packageName,
                                 apkArchitectures = uiState.apkInfo!!.architectures,
+                                apkVersion = uiState.apkInfo!!.versionName,
                                 patchesFilePaths = viewModel.getAllResolvedPatchFiles().map { it.absolutePath },
                                 patchSourceNames = viewModel.getAllResolvedPatchSourceNames(),
                             ))
@@ -582,7 +592,7 @@ fun HomeScreenContent(
                 accum
             }
             val sourceStates: List<SourceLedState> = allSources.map { src ->
-                sourceLedState(src, channelsBySource[src.id])
+                sourceLedState(src, channelsBySource[src.id], hasError = src.id in uiState.failedSourceIds)
             }
             Box(modifier = Modifier.fillMaxSize()) {
                 Column(modifier = Modifier.fillMaxSize()) {
@@ -613,6 +623,16 @@ fun HomeScreenContent(
                             if (uiState.showMultiSourceHint) {
                                 MultiSourceHintBanner(
                                     onDismiss = { viewModel.dismissMultiSourceHint() },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(start = padding, end = padding, top = 8.dp),
+                                )
+                            }
+                            if (uiState.showSourcesFailedBanner) {
+                                SourcesFailedBanner(
+                                    count = uiState.failedSourcesCount,
+                                    onManageSources = { showSourceManagementSheet = true },
+                                    onDismiss = { viewModel.dismissSourcesFailedBanner() },
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .padding(start = padding, end = padding, top = 8.dp),
@@ -654,6 +674,7 @@ fun HomeScreenContent(
                                     isLoading = uiState.isLoadingPatches,
                                     loadError = uiState.patchLoadError,
                                     onRetry = onRetry,
+                                    onManageSources = { showSourceManagementSheet = true },
                                     isCompact = isCompact,
                                     modifier = Modifier
                                         .weight(1.2f)
@@ -731,6 +752,7 @@ private fun handleContinue(
                 patchesFilePath = patchesFile.absolutePath,
                 packageName = info.packageName,
                 apkArchitectures = info.architectures,
+                apkVersion = info.versionName,
                 patchesFilePaths = viewModel.getAllResolvedPatchFiles().map { it.absolutePath },
                 patchSourceNames = viewModel.getAllResolvedPatchSourceNames(),
             ))
@@ -933,6 +955,89 @@ private fun MultiSourceHintBanner(
                 imageVector = Icons.Default.Clear,
                 contentDescription = "Dismiss",
                 tint = accents.primary,
+                modifier = Modifier.size(14.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Non-blocking banner shown when some patch sources loaded but at least one failed.
+ * Patching still works with the loaded sources, so this is an informational warning that
+ * points at the source manager (where each failed source shows exactly why it broke).
+ */
+@Composable
+private fun SourcesFailedBanner(
+    count: Int,
+    onManageSources: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val corners = LocalMorpheCorners.current
+    val mono = LocalMorpheFont.current
+    val accents = LocalMorpheAccents.current
+    val warn = accents.warning
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(corners.small))
+            .border(1.dp, warn.copy(alpha = 0.3f), RoundedCornerShape(corners.small))
+            .background(warn.copy(alpha = 0.06f))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Default.Warning,
+            contentDescription = null,
+            tint = warn,
+            modifier = Modifier.size(15.dp),
+        )
+        Text(
+            text = (if (count == 1) "A patch source" else "$count patch sources") +
+                " failed to load. Using the ones that loaded successfully.",
+            fontSize = 11.sp,
+            fontFamily = mono,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+            letterSpacing = 0.2.sp,
+            modifier = Modifier.weight(1f),
+        )
+        // House-style pill: corners.small with an animated hover border/text, matching the
+        // update banner's actions rather than the default Material TextButton (which used a
+        // full-pill shape and no hover color change).
+        val actionHover = remember { MutableInteractionSource() }
+        val isActionHovered by actionHover.collectIsHoveredAsState()
+        val actionBorder by animateColorAsState(
+            if (isActionHovered) warn.copy(alpha = 0.5f) else MaterialTheme.colorScheme.outline.copy(alpha = 0.2f),
+            animationSpec = tween(150),
+        )
+        val actionText by animateColorAsState(
+            if (isActionHovered) warn else warn.copy(alpha = 0.7f),
+            animationSpec = tween(150),
+        )
+        Box(
+            modifier = Modifier
+                .height(24.dp)
+                .hoverable(actionHover)
+                .clip(RoundedCornerShape(corners.small))
+                .border(1.dp, actionBorder, RoundedCornerShape(corners.small))
+                .clickable(onClick = onManageSources)
+                .padding(horizontal = 8.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                "MANAGE SOURCES",
+                fontFamily = mono,
+                fontSize = 9.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 0.5.sp,
+                color = actionText,
+            )
+        }
+        IconButton(onClick = onDismiss, modifier = Modifier.size(24.dp)) {
+            Icon(
+                imageVector = Icons.Default.Clear,
+                contentDescription = "Dismiss",
+                tint = warn,
                 modifier = Modifier.size(14.dp),
             )
         }
@@ -1350,6 +1455,7 @@ private fun SupportedAppsListPane(
     isLoading: Boolean,
     loadError: String?,
     onRetry: () -> Unit,
+    onManageSources: () -> Unit = {},
     isCompact: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -1476,17 +1582,34 @@ private fun SupportedAppsListPane(
                         textAlign = TextAlign.Center,
                     )
                     Spacer(Modifier.height(10.dp))
-                    OutlinedButton(
-                        onClick = onRetry,
-                        shape = RoundedCornerShape(corners.small),
-                    ) {
-                        Text(
-                            "RETRY",
-                            fontFamily = mono,
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            letterSpacing = 0.5.sp,
-                        )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(
+                            onClick = onRetry,
+                            shape = RoundedCornerShape(corners.small),
+                        ) {
+                            Text(
+                                "RETRY",
+                                fontFamily = mono,
+                                fontSize = 10.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                letterSpacing = 0.5.sp,
+                            )
+                        }
+                        // Always offer a way to the source manager here: when a bundle is
+                        // broken (e.g. needs a newer patcher), fixing it means removing or
+                        // re-pointing that source, so it must be reachable from the error.
+                        OutlinedButton(
+                            onClick = onManageSources,
+                            shape = RoundedCornerShape(corners.small),
+                        ) {
+                            Text(
+                                "MANAGE SOURCES",
+                                fontFamily = mono,
+                                fontSize = 10.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                letterSpacing = 0.5.sp,
+                            )
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeScreen.kt
@@ -103,6 +103,7 @@ import app.morphe.gui.ui.screens.patches.PatchesScreen
 import app.morphe.gui.ui.screens.patches.PatchSelectionScreen
 import app.morphe.gui.util.DownloadUrlResolver.openUrlAndFollowRedirects
 import app.morphe.gui.util.VersionStatus
+import app.morphe.gui.util.humanizePatchLoadError
 import app.morphe.gui.util.resolveStatusColorType
 import app.morphe.gui.util.resolveVersionWarningContent
 import app.morphe.gui.util.toColor
@@ -431,7 +432,12 @@ fun HomeScreenContent(
         val sourceErrors: Map<String, String> = buildMap {
             snapshot?.resolved?.forEach { r -> r.error?.let { put(r.source.id, it) } }
             snapshot?.loaded?.perSource?.forEach { s ->
-                if (!s.isSuccess) put(s.sourceId, s.error?.message ?: "Failed to load")
+                if (!s.isSuccess) {
+                    put(
+                        s.sourceId,
+                        s.error?.let { humanizePatchLoadError(it) } ?: "Failed to load",
+                    )
+                }
             }
         }
         SourceManagementSheet(

--- a/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeViewModel.kt
@@ -197,6 +197,18 @@ class HomeViewModel(
         }
     }
 
+    /** Dismiss the "some sources failed" banner for now. It re-appears if a different
+     *  source starts failing on a later load. */
+    fun dismissSourcesFailedBanner() {
+        sourcesFailedBannerDismissed = true
+        _uiState.value = _uiState.value.copy(showSourcesFailedBanner = false)
+    }
+
+    // Backing state for [dismissSourcesFailedBanner]: the failed-source set last dismissed,
+    // and whether it is currently dismissed. Reset when the failed set changes (see load).
+    private var lastFailedSourceIds: Set<String> = emptySet()
+    private var sourcesFailedBannerDismissed: Boolean = false
+
     /**
      * Begin an "Update" for [record]: resolve the LATEST patch files (ignoring any
      * pinned version — this run only, leaving global config untouched), then work
@@ -358,7 +370,7 @@ class HomeViewModel(
     private fun loadPatchesAndSupportedApps(forceRefresh: Boolean = false) {
         loadJob?.cancel()
         loadJob = screenModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoadingPatches = true, patchLoadError = null)
+            _uiState.value = _uiState.value.copy(isLoadingPatches = true, patchLoadError = null, showSourcesFailedBanner = false)
 
             try {
                 val enabled = patchSourceManager.getEnabledRepositories()
@@ -386,6 +398,10 @@ class HomeViewModel(
                     } else {
                         firstError
                     }
+                    // Logged once per load (not per poll): the per-source failures are only
+                    // surfaced in the UI otherwise, so without this the log file has nothing
+                    // to diagnose a "patches won't load" report from.
+                    Logger.warn("Failed to load any patches: $firstError")
                     _uiState.value = _uiState.value.copy(
                         isLoadingPatches = false,
                         patchLoadError = friendlyError
@@ -426,6 +442,33 @@ class HomeViewModel(
 
                 val patchedStates = computePatchedStates(supportedApps)
                 latestResolvedApps = null // fresh load — drop any stale eager-resolved apps
+
+                // Partial-failure surfacing: some sources loaded, but others may have failed
+                // (e.g. a bundle needing a newer patcher). Collect the failed source ids from
+                // both the resolve phase and the load phase so the banner + per-row FAILED
+                // state agree. Re-show the banner when the failed set changes, even if the
+                // user dismissed a previous one.
+                val failedSourceIds = buildSet {
+                    result.resolved.forEach { if (it.error != null) add(it.source.id) }
+                    result.loaded.perSource.forEach { if (!it.isSuccess) add(it.sourceId) }
+                }
+                if (failedSourceIds.isNotEmpty()) {
+                    // One WARN summary per load (name: reason for each failed source), so a
+                    // partial failure — which is otherwise only shown in the UI — is captured
+                    // in the log file for diagnosing user reports.
+                    val details = buildList {
+                        result.resolved.forEach { r -> r.error?.let { add("${r.source.name}: $it") } }
+                        result.loaded.perSource.forEach { s ->
+                            if (!s.isSuccess) add("${s.sourceName}: ${s.error?.message ?: "failed to load"}")
+                        }
+                    }
+                    Logger.warn("Some patch sources failed to load — ${details.joinToString("; ")}")
+                }
+                if (failedSourceIds != lastFailedSourceIds) {
+                    sourcesFailedBannerDismissed = false
+                    lastFailedSourceIds = failedSourceIds
+                }
+
                 _uiState.value = _uiState.value.copy(
                     isLoadingPatches = false,
                     isOffline = isOffline,
@@ -437,7 +480,10 @@ class HomeViewModel(
                     latestPatchesVersion = displayVersion,
                     latestDevPatchesVersion = null,
                     patchSourceName = sourceName,
-                    patchLoadError = null
+                    patchLoadError = null,
+                    showSourcesFailedBanner = failedSourceIds.isNotEmpty() && !sourcesFailedBannerDismissed,
+                    failedSourcesCount = failedSourceIds.size,
+                    failedSourceIds = failedSourceIds,
                 )
                 refreshDeviceInfo() // records just (re)loaded — refresh the optional device layer
                 reanalyzeSelectedApk()
@@ -448,7 +494,12 @@ class HomeViewModel(
                 // write UI state — otherwise a stale "Job was cancelled" can
                 // clobber the in-flight successor's loading/success state.
                 throw e
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                // Throwable, not just Exception: a bundle built against a newer patcher
+                // throws java.lang.Error (NoSuchMethodError / LinkageError) at link time.
+                // As an Error it would slip past catch(Exception), leaving isLoadingPatches
+                // stuck true and the loading skeleton animating forever with no way to reach
+                // the source manager. Widening it guarantees loading always ends in a state.
                 Logger.error("Failed to load patches and supported apps", e)
                 _uiState.value = _uiState.value.copy(
                     isLoadingPatches = false,
@@ -1253,6 +1304,13 @@ data class HomeUiState(
     /** True when more than one source is enabled and the user hasn't dismissed
      *  the one-time multi-source intro hint yet. */
     val showMultiSourceHint: Boolean = false,
+    /** True when some patch sources loaded but at least one failed. Drives the
+     *  non-blocking "some sources failed" banner. */
+    val showSourcesFailedBanner: Boolean = false,
+    /** How many sources failed to load (for the banner copy). */
+    val failedSourcesCount: Int = 0,
+    /** Source ids that failed to load. Drives the red status LED on the home pill. */
+    val failedSourceIds: Set<String> = emptySet(),
 ) {
     /**
      * Show the update banner only when an update was found AND the user hasn't

--- a/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeViewModel.kt
@@ -390,18 +390,27 @@ class HomeViewModel(
                 val result = EnabledSourcesLoader.loadAll(enabled, patchService, prefs)
 
                 if (!result.anyLoaded) {
+                    val firstThrowable = result.loaded.perSource.firstNotNullOfOrNull { it.error }
                     val firstError = result.resolved.firstNotNullOfOrNull { it.error }
-                        ?: result.loaded.perSource.firstNotNullOfOrNull { it.error?.message }
+                        ?: firstThrowable?.let { humanizePatchLoadError(it) }
                         ?: "Could not load any patches"
                     val friendlyError = if (firstError.contains("zip", ignoreCase = true) || firstError.contains("END header", ignoreCase = true)) {
                         "Patch file is missing or corrupted. Clear cache and re-download."
                     } else {
                         firstError
                     }
-                    // Logged once per load (not per poll): the per-source failures are only
-                    // surfaced in the UI otherwise, so without this the log file has nothing
-                    // to diagnose a "patches won't load" report from.
-                    Logger.warn("Failed to load any patches: $firstError")
+                    // Log the real throwable (full stack). Never only a null/blank .message.
+                    if (firstThrowable != null) {
+                        Logger.error("Failed to load any patches: $friendlyError", firstThrowable)
+                    } else {
+                        Logger.warn("Failed to load any patches: $firstError")
+                    }
+                    result.loaded.perSource.filter { !it.isSuccess }.forEach { src ->
+                        val err = src.error
+                        if (err != null) {
+                            Logger.error("Patch source '${src.sourceName}' failed to load", err)
+                        }
+                    }
                     _uiState.value = _uiState.value.copy(
                         isLoadingPatches = false,
                         patchLoadError = friendlyError
@@ -453,13 +462,18 @@ class HomeViewModel(
                     result.loaded.perSource.forEach { if (!it.isSuccess) add(it.sourceId) }
                 }
                 if (failedSourceIds.isNotEmpty()) {
-                    // One WARN summary per load (name: reason for each failed source), so a
-                    // partial failure — which is otherwise only shown in the UI — is captured
-                    // in the log file for diagnosing user reports.
+                    // One summary + full stack per failed source so partial failures are
+                    // diagnosable from the log file (not only a red "Failed to load" LED).
                     val details = buildList {
                         result.resolved.forEach { r -> r.error?.let { add("${r.source.name}: $it") } }
                         result.loaded.perSource.forEach { s ->
-                            if (!s.isSuccess) add("${s.sourceName}: ${s.error?.message ?: "failed to load"}")
+                            if (!s.isSuccess) {
+                                val err = s.error
+                                add("${s.sourceName}: ${err?.let { humanizePatchLoadError(it) } ?: "failed to load"}")
+                                if (err != null) {
+                                    Logger.error("Patch source '${s.sourceName}' failed to load", err)
+                                }
+                            }
                         }
                     }
                     Logger.warn("Some patch sources failed to load — ${details.joinToString("; ")}")

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionScreen.kt
@@ -108,6 +108,9 @@ data class PatchSelectionScreen(
     val initialSelectionByBundle: Map<String, Set<String>> = emptyMap(),
     /** One-click repatch option seed ("patchName.optionKey" → value). */
     val initialPatchOptions: Map<String, String> = emptyMap(),
+    /** The app's versionName (parsed from the APK), threaded to the output-name helper so
+     *  the filename is unique by app version even for renamed bundles. Blank = not supplied. */
+    val apkVersion: String = "",
 ) : Screen {
 
     @Composable
@@ -117,6 +120,7 @@ data class PatchSelectionScreen(
             parametersOf(
                 apkPath, apkName, patchesFilePath, packageName, apkArchitectures,
                 effectiveList, patchSourceNames, initialSelectionByBundle, initialPatchOptions,
+                apkVersion,
             )
         }
         PatchSelectionScreenContent(viewModel = viewModel)

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionViewModel.kt
@@ -70,6 +70,11 @@ class PatchSelectionViewModel(
     private val initialSelectionByBundle: Map<String, Set<String>> = emptyMap(),
     /** One-click repatch seed: "patchName.optionKey" → option value. */
     private val initialPatchOptions: Map<String, String> = emptyMap(),
+    /** The app's versionName (parsed from the APK upstream). Threaded here so the output
+     *  filename stays unique by app version even for renamed bundles the engine can't
+     *  re-read a version from. Blank falls back to the engine's manifest/filename resolution.
+     *  Non-null (rather than String?) so no null flows through the Koin parametersOf chain. */
+    private val apkVersion: String = "",
 ) : ScreenModel {
 
     // Actual path to use for the primary file — may differ from patchesFilePath
@@ -530,6 +535,7 @@ class PatchSelectionViewModel(
             patchesFile = File(actualPatchesFilePath),
             baseOutputDir = defaultOutputDirectory?.let { File(it) },
             appDisplayName = apkName,
+            appVersion = apkVersion,
         ).absolutePath
 
         // Flatten across bundles: the engine takes a single flat enable/disable

--- a/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchViewModel.kt
@@ -246,7 +246,10 @@ class QuickPatchViewModel(
                 // state from a cancelled load — the cancellation race would
                 // clobber a successor's progress with a stale error.
                 throw e
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                // Throwable, not just Exception: a bundle built against a newer patcher
+                // throws java.lang.Error (NoSuchMethodError / LinkageError) at link time,
+                // which would slip past catch(Exception) and leave the loader stuck forever.
                 Logger.error("Quick mode: Failed to load patches", e)
                 _uiState.value = _uiState.value.copy(
                     isLoadingPatches = false,
@@ -489,6 +492,7 @@ class QuickPatchViewModel(
                 patchesFile = patchFile,
                 baseOutputDir = appConfig.resolvedDefaultOutputDirectory(),
                 appDisplayName = apkInfo.displayName,
+                appVersion = apkInfo.versionName,
             ).absolutePath
 
             // Resolve keystore — see PatchingViewModel for the full rationale.

--- a/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchViewModel.kt
@@ -199,9 +199,18 @@ class QuickPatchViewModel(
                 val result = EnabledSourcesLoader.loadAll(listOf(pair), patchService)
 
                 if (!result.anyLoaded) {
+                    val firstThrowable = result.loaded.perSource.firstNotNullOfOrNull { it.error }
                     val firstError = result.resolved.firstNotNullOfOrNull { it.error }
-                        ?: result.loaded.perSource.firstNotNullOfOrNull { it.error?.message }
+                        ?: firstThrowable?.let { humanizePatchLoadError(it) }
                         ?: "Could not load any patches"
+                    if (firstThrowable != null) {
+                        Logger.error("Quick mode: Failed to load any patches: $firstError", firstThrowable)
+                    } else {
+                        Logger.warn("Quick mode: Failed to load any patches: $firstError")
+                    }
+                    result.loaded.perSource.filter { !it.isSuccess }.forEach { src ->
+                        src.error?.let { Logger.error("Quick mode: source '${src.sourceName}' failed", it) }
+                    }
                     _uiState.value = _uiState.value.copy(
                         isLoadingPatches = false,
                         patchLoadError = firstError

--- a/src/main/kotlin/app/morphe/gui/ui/theme/ChannelColors.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/theme/ChannelColors.kt
@@ -32,6 +32,8 @@ fun channelColor(channel: Channel?): Color {
         Channel.STABLE_OLDER -> accents.warning
         Channel.DEV_LATEST -> accents.tertiary
         Channel.DEV_OLDER -> MaterialTheme.colorScheme.error
+        // Local files aren't a release channel, so give them their own distinct tint.
+        Channel.LOCAL -> accents.primary
         null, Channel.UNKNOWN -> accents.secondary
     }
 }

--- a/src/main/kotlin/app/morphe/gui/util/AdbManager.kt
+++ b/src/main/kotlin/app/morphe/gui/util/AdbManager.kt
@@ -285,7 +285,10 @@ class AdbManager {
             }
 
             val devices = parseDeviceList(output, adb)
-            Logger.info("Found ${devices.size} device(s)")
+            // No per-call log here: this runs on every 5s device poll, and the log file
+            // has no level filtering (debug writes too), so any line here floods it.
+            // Connect / disconnect / status transitions are logged once each by
+            // DeviceMonitor.refreshDevices instead.
             Result.success(devices)
         } catch (e: Exception) {
             Logger.error("Error getting devices", e)

--- a/src/main/kotlin/app/morphe/gui/util/DeviceMonitor.kt
+++ b/src/main/kotlin/app/morphe/gui/util/DeviceMonitor.kt
@@ -76,6 +76,24 @@ object DeviceMonitor {
         result.fold(
             onSuccess = { devices ->
                 val currentState = _state.value
+
+                // Log only transitions, not the (unchanged) result of every 5s poll.
+                // Connect / disconnect / authorization-status changes are the events worth
+                // recording; a steady state produces no log lines.
+                val previousById = currentState.devices.associateBy { it.id }
+                val currentById = devices.associateBy { it.id }
+                devices.forEach { dev ->
+                    val prev = previousById[dev.id]
+                    when {
+                        prev == null -> Logger.info("Device connected: ${dev.id} (${dev.status})")
+                        prev.status != dev.status ->
+                            Logger.info("Device ${dev.id} status changed: ${prev.status} -> ${dev.status}")
+                    }
+                }
+                currentState.devices.forEach { prev ->
+                    if (prev.id !in currentById) Logger.info("Device disconnected: ${prev.id}")
+                }
+
                 val readyDevices = devices.filter { it.isReady }
 
                 // Determine selected device

--- a/src/main/kotlin/app/morphe/gui/util/EnabledSourcesLoader.kt
+++ b/src/main/kotlin/app/morphe/gui/util/EnabledSourcesLoader.kt
@@ -40,7 +40,7 @@ object EnabledSourcesLoader {
      */
     /** What channel the resolved release is on. Used by the home pill LEDs and
      *  the sheet's channel badge so we don't keep re-deriving from tag strings. */
-    enum class Channel { STABLE_LATEST, STABLE_OLDER, DEV_LATEST, DEV_OLDER, UNKNOWN }
+    enum class Channel { STABLE_LATEST, STABLE_OLDER, DEV_LATEST, DEV_OLDER, LOCAL, UNKNOWN }
 
     data class ResolvedSource(
         val source: PatchSource,
@@ -166,6 +166,9 @@ object EnabledSourcesLoader {
             patchFile = file,
             resolvedVersion = file.nameWithoutExtension,
             isOffline = false,
+            // A local file has no release channel, so tag it LOCAL rather than letting
+            // it fall through to the STABLE_LATEST default used for remote sources.
+            channel = Channel.LOCAL,
         )
     }
 

--- a/src/main/kotlin/app/morphe/gui/util/Logger.kt
+++ b/src/main/kotlin/app/morphe/gui/util/Logger.kt
@@ -5,6 +5,7 @@
 
 package app.morphe.gui.util
 
+import app.morphe.engine.MorpheComponents
 import app.morphe.gui.data.constants.AppConstants
 import java.io.File
 import java.io.PrintWriter
@@ -54,6 +55,8 @@ object Logger {
             info("=".repeat(60))
             info("Morphe-GUI Started")
             info("Version: ${AppConstants.APP_VERSION}")
+            info("morphe-patcher: ${MorpheComponents.patcherVersion ?: "unknown"}")
+            info("morphe-library: ${MorpheComponents.libraryVersion ?: "unknown"}")
             info("OS: ${System.getProperty("os.name")} ${System.getProperty("os.version")} (${System.getProperty("os.arch")})")
             info("Java: ${System.getProperty("java.version")} (${System.getProperty("java.vendor")}) ${System.getProperty("sun.arch.data.model")}-bit")
             info("Memory: ${Runtime.getRuntime().maxMemory() / 1024 / 1024} MB max")

--- a/src/main/kotlin/app/morphe/gui/util/PatchLoadErrorMessage.kt
+++ b/src/main/kotlin/app/morphe/gui/util/PatchLoadErrorMessage.kt
@@ -43,5 +43,12 @@ fun humanizePatchLoadError(e: Throwable): String = when (e) {
         }
     }
 
+    // A bundle built against a newer patcher fails at link time with java.lang.Error
+    // subclasses (NoSuchMethodError / NoClassDefFoundError / AbstractMethodError, all
+    // LinkageError). The per-source loader gives a precise version message where it can,
+    // this is the catch-all when only the throwable is available.
+    is LinkageError ->
+        "This patch bundle needs a newer version of Morphe. Update Morphe and try again."
+
     else -> e.message?.takeIf { it.isNotBlank() } ?: "Could not load patches"
 }

--- a/src/main/kotlin/app/morphe/gui/util/PatchLoadErrorMessage.kt
+++ b/src/main/kotlin/app/morphe/gui/util/PatchLoadErrorMessage.kt
@@ -5,6 +5,9 @@
 
 package app.morphe.gui.util
 
+import app.morphe.engine.PatchBundleIncompatibleException
+import app.morphe.engine.PatchSourceLoadException
+import app.morphe.engine.readableMessage
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
@@ -15,13 +18,13 @@ import java.net.UnknownHostException
  * Map a load failure exception to a short, user-readable line.
  *
  * The raw `Exception.message` is hostile when the underlying cause is a
- * coroutine/Ktor internal — users see "StandaloneCoroutine was cancelled"
+ * coroutine/Ktor internal. Users see "StandaloneCoroutine was cancelled"
  * and assume the app crashed. This translates the common network/IO failures
- * into plain English and falls back to the original message for anything we
- * don't recognize.
+ * into plain English and falls back to the **full cause-chain message** for
+ * anything we don't recognize (never a blank "Failed to load").
  *
- * Intentionally does NOT handle CancellationException — that should never
- * reach the UI; callers must re-throw it from their catch blocks instead of
+ * Intentionally does NOT handle CancellationException. That should never
+ * reach the UI. Callers must re-throw it from their catch blocks instead of
  * surfacing it as an error.
  */
 fun humanizePatchLoadError(e: Throwable): String = when (e) {
@@ -43,12 +46,16 @@ fun humanizePatchLoadError(e: Throwable): String = when (e) {
         }
     }
 
+    // Already expanded by MultiSourceLoader / PatcherCompatibility
+    is PatchBundleIncompatibleException,
+    is PatchSourceLoadException -> e.message?.takeIf { it.isNotBlank() } ?: e.readableMessage()
+
     // A bundle built against a newer patcher fails at link time with java.lang.Error
     // subclasses (NoSuchMethodError / NoClassDefFoundError / AbstractMethodError, all
-    // LinkageError). The per-source loader gives a precise version message where it can,
-    // this is the catch-all when only the throwable is available.
-    is LinkageError ->
-        "This patch bundle needs a newer version of Morphe. Update Morphe and try again."
+    // LinkageError). Prefer the concrete type/message chain so the user (and logs) see
+    // *which* symbol is missing, not a generic "update Morphe".
+    is LinkageError -> e.readableMessage()
 
-    else -> e.message?.takeIf { it.isNotBlank() } ?: "Could not load patches"
+    // ExceptionInInitializerError and friends often have null .message.
+    else -> e.readableMessage()
 }

--- a/src/main/resources/app/morphe/cli/version.properties
+++ b/src/main/resources/app/morphe/cli/version.properties
@@ -1,1 +1,2 @@
 version=${projectVersion}
+patcherVersion=${patcherVersion}

--- a/src/main/resources/app/morphe/cli/version.properties
+++ b/src/main/resources/app/morphe/cli/version.properties
@@ -1,2 +1,1 @@
 version=${projectVersion}
-patcherVersion=${patcherVersion}


### PR DESCRIPTION
- Failing to load a patch source now properly throws an error instead of loading forever. We also show a banner mentioning that a patch source has failed to load.
- abd logs are now quieter. Now only connect, disconnect, and status transitions are logged.
- Output names already tried to encode the app version, but it came from the input filename, so a renamed input fell back to "patched" and different app versions overwrote each other. The app version is now read from the APK manifest (versionName) properly.
- Also changed how the LEDs work on the source sheet and the source pill. The LEDs now properly reflect the state of the patch source instead of just showing what is active or inactive.
- Patcher version is now properly read from classpath instead of trusting the libs.toml file.
- Patch load failures no longer surface as a blank "Failed to load". Full chain is logged and shown in the UI. (Even when the .message is null (might need more fixing in other places.)
- Log the patcher and library info in the logs and the tools dialog.