### PR TITLE
fix: resolve deprecation warnings and fix `list-versions` accuracy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,15 +75,15 @@ dependencies {
     // -- Compose Desktop ---------------------------------------------------
     // Platform-independent: single JAR runs on all supported OSes.
     // Skiko auto-detects the OS at runtime and loads the correct native library.
-    implementation(compose.desktop.macos_arm64)
-    implementation(compose.desktop.macos_x64)
-    implementation(compose.desktop.linux_x64)
-    implementation(compose.desktop.linux_arm64)
-    implementation(compose.desktop.windows_x64)
-    implementation(compose.components.resources)
+    implementation("org.jetbrains.compose.desktop:desktop-jvm-macos-arm64:${libs.versions.compose.get()}")
+    implementation("org.jetbrains.compose.desktop:desktop-jvm-macos-x64:${libs.versions.compose.get()}")
+    implementation("org.jetbrains.compose.desktop:desktop-jvm-linux-x64:${libs.versions.compose.get()}")
+    implementation("org.jetbrains.compose.desktop:desktop-jvm-linux-arm64:${libs.versions.compose.get()}")
+    implementation("org.jetbrains.compose.desktop:desktop-jvm-windows-x64:${libs.versions.compose.get()}")
+    implementation("org.jetbrains.compose.components:components-resources:${libs.versions.compose.get()}")
     @Suppress("DEPRECATION")
     implementation(compose.material3)
-    implementation(compose.materialIconsExtended)
+    implementation("org.jetbrains.compose.material:material-icons-extended-desktop:1.7.3")
 
     // -- Async / Serialization ---------------------------------------------
     implementation(libs.kotlinx.coroutines.core)

--- a/src/main/kotlin/app/morphe/desktop/command/ListPatchesCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/ListPatchesCommand.kt
@@ -117,13 +117,13 @@ internal object ListPatchesCommand : Runnable {
     override fun run() {
         fun PatchOption<*>.buildString() =
             buildString {
-                appendLine("Title: $title")
+                appendLine("Title: $name")
                 description?.let { appendLine("Description: $it") }
                 appendLine("Required: $required")
                 default?.let {
-                    appendLine("Key: $key")
+                    appendLine("Key: $name")
                     append("Default: $it")
-                } ?: append("Key: $key")
+                } ?: append("Key: $name")
 
                 values?.let { values ->
                     appendLine("\nPossible values:")
@@ -142,7 +142,7 @@ internal object ListPatchesCommand : Runnable {
 
                     if (withDescriptions) append("\nDescription: ${patch.description}")
 
-                    append("\nEnabled: ${patch.use}")
+                    append("\nEnabled: ${patch.default}")
 
                     if (withOptions && patch.options.isNotEmpty()) {
                         appendLine("\nOptions:")

--- a/src/main/kotlin/app/morphe/desktop/command/OptionsCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/OptionsCommand.kt
@@ -6,6 +6,7 @@
 package app.morphe.desktop.command
 
 import app.morphe.desktop.command.model.PatchBundle
+import app.morphe.engine.isCompatibleWith
 import app.morphe.engine.patches.LoadedBundle
 import app.morphe.engine.patches.PatchBundleLoader
 import app.morphe.desktop.command.model.findMatchingBundle
@@ -112,12 +113,15 @@ internal object OptionsCommand : Callable<Int> {
             // For each bundle: apply optional package filter, find its matching JSON
             // entry (by source filename), merge, splice updated entry back into the running list.
             var updatedBundles = existingBundles
+            val pkg = packageName
             loadedBundles.forEach { lb ->
-                val filtered = packageName?.let { pkg ->
-                    lb.patches.filter { patch ->
-                        patch.compatiblePackages?.any { (name, _) -> name == pkg } ?: true
-                    }.toSet()
-                } ?: lb.patches
+                val filtered = lb.patches.filter { patch ->
+                    pkg == null || patch.isCompatibleWith(
+                        packageName = pkg,
+                        includeExperimental = true,
+                        includeUniversalPatches = true,
+                    )
+                }.toSet()
 
                 val existingBundle = updatedBundles.findMatchingBundle(setOf(lb.sourceFile))
                 val updatedBundle = filtered.mergeWithBundle(

--- a/src/main/kotlin/app/morphe/desktop/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/PatchCommand.kt
@@ -10,6 +10,8 @@ package app.morphe.desktop.command
 
 import app.morphe.desktop.command.model.*
 import app.morphe.desktop.command.CliHttpClient
+import app.morphe.engine.isCompatibleWith
+import app.morphe.engine.compatibleVersionsForDisplay
 import app.morphe.engine.MorpheData
 import app.morphe.engine.supportedVersionsFor
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_KEYSTORE_ALIAS
@@ -641,13 +643,11 @@ internal object PatchCommand : Callable<Int> {
 
                         val compatiblePatchNames = bundlePatches
                             .filter { patch ->
-                                val compat = patch.compatibility
-                                if (!compat.isNullOrEmpty()) {
-                                    compat.any { it.packageName == packageName || it.packageName == null }
-                                } else {
-                                    @Suppress("DEPRECATION")
-                                    patch.compatiblePackages == null || patch.compatiblePackages!!.any { (name, _) -> name == packageName }
-                                }
+                                patch.isCompatibleWith(
+                                    packageName = packageName,
+                                    includeExperimental = true,
+                                    includeUniversalPatches = true,
+                                )
                             }
                             .mapNotNull { it.name?.lowercase() }
                             .toSet()
@@ -676,13 +676,11 @@ internal object PatchCommand : Callable<Int> {
                             // so multi-app patches with the same name aren't merged together.
                             val actualPatch = bundlePatches.find { patch ->
                                 if (!patch.name.equals(patchName, ignoreCase = true)) return@find false
-                                val compat = patch.compatibility
-                                if (!compat.isNullOrEmpty()) {
-                                    compat.any { it.packageName == packageName || it.packageName == null }
-                                } else {
-                                    @Suppress("DEPRECATION")
-                                    patch.compatiblePackages == null || patch.compatiblePackages!!.any { (name, _) -> name == packageName }
-                                }
+                                patch.isCompatibleWith(
+                                    packageName = packageName,
+                                    includeExperimental = true,
+                                    includeUniversalPatches = true,
+                                )
                             }
                             val actualOptionKeys = actualPatch?.options?.keys ?: emptySet()
 
@@ -1002,12 +1000,9 @@ internal object PatchCommand : Callable<Int> {
                     return@patchLoop logger.fine(
                         "Skipping \"$patchName\": incompatible with $packageName " +
                             "(only compatible with " +
-                            (patch.compatibility
-                                ?.mapNotNull { it.packageName }
-                                ?.joinToString(", ")
-                                ?: @Suppress("DEPRECATION") patch.compatiblePackages
-                                    ?.joinToString(", ") { (name, _) -> name }
-                                ?: "") + ")"
+                            patch.compatibleVersionsForDisplay(includeExperimental = true)
+                                .mapNotNull { (name, _) -> name }
+                                .joinToString(", ") + ")"
                     )
                 }
                 supportedVersions != null -> {

--- a/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
@@ -140,7 +140,7 @@ fun Iterable<Patch<*>>.mostCommonCompatibleVersions(
         val versionCount = VersionMap()
 
         for (patch in this) {
-            if (!countUnusedPatches && !patch.use) continue
+            if (!countUnusedPatches && !patch.default) continue
 
             val compat = patch.compatibility
 
@@ -157,8 +157,6 @@ fun Iterable<Patch<*>>.mostCommonCompatibleVersions(
                         .filter { includeExperimental || !it.isExperimental }
                         .mapNotNull { it.version }
                 }
-
-                if (versions.isEmpty() && !isUniversal) continue
 
                 if (versions.isEmpty()) {
                     versionCount[""] = (versionCount[""] ?: 0) + 1

--- a/src/main/kotlin/app/morphe/engine/UpdateChecker.kt
+++ b/src/main/kotlin/app/morphe/engine/UpdateChecker.kt
@@ -6,6 +6,7 @@
 package app.morphe.engine
 
 import java.net.HttpURLConnection
+import java.net.URI
 import java.net.URL
 import java.util.Properties
 import java.util.logging.Logger
@@ -50,7 +51,7 @@ object UpdateChecker {
                     "https://raw.githubusercontent.com/MorpheApp/morphe-desktop/refs/heads/main/gradle.properties"
             }
 
-            val connection = URL(url).openConnection() as HttpURLConnection
+            val connection = URI(url).toURL().openConnection() as HttpURLConnection
             connection.connectTimeout = 3000
             connection.readTimeout = 3000
 

--- a/src/main/kotlin/app/morphe/gui/App.kt
+++ b/src/main/kotlin/app/morphe/gui/App.kt
@@ -29,6 +29,7 @@ import app.morphe.gui.di.appModule
 import kotlinx.coroutines.launch
 import org.koin.compose.KoinApplication
 import org.koin.compose.koinInject
+import org.koin.dsl.koinConfiguration
 import app.morphe.gui.ui.screens.home.HomeScreen
 import app.morphe.gui.ui.screens.quick.QuickPatchContent
 import app.morphe.gui.ui.screens.quick.QuickPatchViewModel
@@ -75,7 +76,7 @@ fun App(
         Logger.init()
     }
 
-    KoinApplication(application = {
+    KoinApplication(koinConfiguration {
         modules(appModule)
     }) {
         AppContent(initialSimplifiedMode = initialSimplifiedMode)

--- a/src/main/kotlin/app/morphe/gui/data/repository/ConfigRepository.kt
+++ b/src/main/kotlin/app/morphe/gui/data/repository/ConfigRepository.kt
@@ -135,7 +135,7 @@ class ConfigRepository {
         // mapped onto the default source).
         val legacyTags: Map<String, String> = when {
             current.lastPatchesVersionBySource.isNotEmpty() -> current.lastPatchesVersionBySource
-            current.lastPatchesVersion != null -> mapOf(DEFAULT_PATCH_SOURCE.id to current.lastPatchesVersion!!)
+            current.lastPatchesVersion != null -> mapOf(DEFAULT_PATCH_SOURCE.id to current.lastPatchesVersion)
             else -> emptyMap()
         }
         if (legacyTags.isEmpty()) return emptyMap()

--- a/src/main/kotlin/app/morphe/gui/ui/components/LicensesDialog.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/LicensesDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -45,6 +46,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.morphe.gui.ui.theme.LocalMorpheAccents
@@ -56,8 +58,7 @@ import app.morphe.gui.util.Logger
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.entity.License
-import java.awt.Desktop
-import java.net.URI
+
 
 @Composable
 internal fun LicensesDialog(onDismiss: () -> Unit) {
@@ -580,6 +581,7 @@ private fun LinkPill(
 ) {
     val hover = remember { MutableInteractionSource() }
     val isHovered by hover.collectIsHoveredAsState()
+    val uriHandler = LocalUriHandler.current
     Row(
         modifier = Modifier
             .hoverable(hover)
@@ -589,7 +591,7 @@ private fun LinkPill(
                 if (isHovered) borderColor.copy(alpha = 0.4f) else borderColor,
                 RoundedCornerShape(corners.small)
             )
-            .clickable { openUrl(url) }
+            .clickable { uriHandler.openUri(url) }
             .padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -602,9 +604,8 @@ private fun LinkPill(
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = if (isHovered) 0.9f else 0.6f),
             letterSpacing = 1.sp
         )
-        @Suppress("DEPRECATION")
         Icon(
-            imageVector = Icons.Default.OpenInNew,
+            imageVector = Icons.AutoMirrored.Default.OpenInNew,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = if (isHovered) 0.75f else 0.45f),
             modifier = Modifier.size(10.dp)
@@ -943,14 +944,4 @@ private fun licenseDisplayLabel(license: License): String {
     val hash = license.hash
     if (hash.isNotBlank() && !MD5_HASH_REGEX.matches(hash)) return hash
     return license.name.ifBlank { "—" }
-}
-
-private fun openUrl(url: String) {
-    try {
-        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-            Desktop.getDesktop().browse(URI.create(url))
-        }
-    } catch (e: Exception) {
-        Logger.error("Failed to open url: $url", e)
-    }
 }

--- a/src/main/kotlin/app/morphe/gui/ui/components/LottieAnimation.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/LottieAnimation.kt
@@ -3,6 +3,8 @@
  * https://github.com/MorpheApp/morphe-desktop
  */
 
+@file:Suppress("DEPRECATION")
+
 package app.morphe.gui.ui.components
 
 import androidx.compose.foundation.Canvas

--- a/src/main/kotlin/app/morphe/gui/ui/components/SettingsDialog.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SettingsDialog.kt
@@ -1138,7 +1138,7 @@ private fun SigningSection(
                 onClick = {
                     verifyResult = null
                     verifySuccess = false
-                    val path = keystorePath ?: return@OutlinedButton
+                    val path = keystorePath
                     val result = readKeystoreInfo(
                         path,
                         localPassword.ifEmpty { null },
@@ -1622,7 +1622,7 @@ private fun readKeystoreInfo(
 
             return KeystoreInfoResult(
                 alias = alias,
-                issuer = cert.issuerDN.name,
+                issuer = cert.issuerX500Principal.name,
                 validFrom = dateFormat.format(cert.notBefore),
                 validTo = dateFormat.format(cert.notAfter),
                 sha256Fingerprint = sha256,

--- a/src/main/kotlin/app/morphe/gui/ui/screens/home/components/SupportedAppListRow.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/home/components/SupportedAppListRow.kt
@@ -311,7 +311,7 @@ private fun VersionChip(
                 if (isLink) Modifier
                     .pointerHoverIcon(PointerIcon.Hand)
                     .clickable {
-                        openUrlAndFollowRedirects(downloadUrl!!) { uriHandler.openUri(it) }
+                        openUrlAndFollowRedirects(downloadUrl) { uriHandler.openUri(it) }
                     }
                 else Modifier
             )
@@ -501,7 +501,7 @@ private fun Pill(
                 if (isInteractive) Modifier
                     .pointerHoverIcon(PointerIcon.Hand)
                     .pointerInput(onClick) {
-                        detectTapGestures(onTap = { onClick?.invoke() })
+                        detectTapGestures(onTap = { onClick() })
                     }
                 else Modifier
             )

--- a/src/main/kotlin/app/morphe/gui/ui/screens/home/components/YourAppsPane.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/home/components/YourAppsPane.kt
@@ -605,7 +605,7 @@ fun PatchedAppDetailDialog(
                 val updateSub = updateInfo?.let { updateSummary(it) }
                 // Already-patched APK ready to install (no re-patch) — primary action.
                 if (installPending) {
-                    val sub = if (deviceInfo?.installed == true)
+                    val sub = if (deviceInfo.installed)
                         "v${record.apkVersion.removePrefix("v")} ready · device on v${deviceInfo.installedVersion?.removePrefix("v") ?: "?"}"
                     else "v${record.apkVersion.removePrefix("v")} ready — no re-patch needed"
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionScreen.kt
@@ -249,7 +249,7 @@ fun PatchSelectionScreenContent(viewModel: PatchSelectionViewModel) {
             }
 
             // Command preview toggle
-            if (!uiState.isLoading && uiState.allPatches.isNotEmpty()) {
+            if (!uiState.isLoading && uiState.bundles.isNotEmpty()) {
                 val cmdHover = remember { MutableInteractionSource() }
                 val isCmdHovered by cmdHover.collectIsHoveredAsState()
                 val cmdActive = showCommandPreview
@@ -301,7 +301,7 @@ fun PatchSelectionScreenContent(viewModel: PatchSelectionViewModel) {
                 )
 
                 TooltipBox(
-                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
                     tooltip = {
                         PlainTooltip {
                             Text(
@@ -351,8 +351,8 @@ fun PatchSelectionScreenContent(viewModel: PatchSelectionViewModel) {
         }
 
         // Command preview — collapsible
-        if (!uiState.isLoading && uiState.allPatches.isNotEmpty()) {
-            val commandPreview = remember(uiState.selectedPatches, uiState.stripLibsStatus, cleanMode, continueOnError, keystorePath) {
+        if (!uiState.isLoading && uiState.bundles.isNotEmpty()) {
+            val commandPreview = remember(uiState.selectedByBundle, uiState.stripLibsStatus, cleanMode, continueOnError, keystorePath) {
                 viewModel.getCommandPreview(cleanMode, continueOnError, keystorePath, keystorePassword, keystoreAlias, keystoreEntryPassword)
             }
             AnimatedVisibility(
@@ -599,7 +599,7 @@ fun PatchSelectionScreenContent(viewModel: PatchSelectionViewModel) {
                 ) {
                     val patchHover = remember { MutableInteractionSource() }
                     val isPatchHovered by patchHover.collectIsHoveredAsState()
-                    val patchEnabled = uiState.selectedPatches.isNotEmpty()
+                    val patchEnabled = uiState.selectedCount > 0
                     val patchBg by animateColorAsState(
                         when {
                             !patchEnabled -> accents.primary.copy(alpha = 0.1f)

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingScreen.kt
@@ -34,13 +34,16 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.ExperimentalComposeUiApi
+import kotlinx.coroutines.launch
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import java.awt.datatransfer.StringSelection
 import java.io.File
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.koinScreenModel
@@ -719,6 +722,7 @@ private fun getStatusColor(status: PatchingStatus): Color {
 }
 
 @Composable
+@OptIn(ExperimentalComposeUiApi::class)
 private fun LogFileViewerDialog(
     file: File,
     corners: app.morphe.gui.ui.theme.MorpheCornerStyle,
@@ -727,7 +731,8 @@ private fun LogFileViewerDialog(
     onDismiss: () -> Unit,
 ) {
     val accents = LocalMorpheAccents.current
-    val clipboard = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardScope = rememberCoroutineScope()
 
     // Read file once on open. Logs are line-oriented text, typically well
     // under a few MB; if a single patching session ever produces something
@@ -798,7 +803,11 @@ private fun LogFileViewerDialog(
                             .clip(RoundedCornerShape(corners.small))
                             .background(copyBg)
                             .clickable {
-                                clipboard.setText(AnnotatedString(content))
+                                clipboardScope.launch {
+                                    clipboard.setClipEntry(
+                                        ClipEntry(StringSelection(content))
+                                    )
+                                }
                                 copied = true
                             }
                             .padding(horizontal = 10.dp, vertical = 6.dp)

--- a/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchScreen.kt
@@ -390,7 +390,7 @@ private fun PatchesVersionBadge(
                 .then(
                     if (interactive) Modifier
                         .pointerHoverIcon(androidx.compose.ui.input.pointer.PointerIcon.Hand)
-                        .clickable(onClick = onClick!!)
+                        .clickable(onClick = onClick)
                     else Modifier
                 )
                 .padding(horizontal = 12.dp),

--- a/src/main/kotlin/app/morphe/gui/util/AdbManager.kt
+++ b/src/main/kotlin/app/morphe/gui/util/AdbManager.kt
@@ -579,8 +579,8 @@ class AdbManager {
 
         var stockChanged = false
         if (stockEligible) {
-            val stockCommands = if (enable) AppLinkCommands.disableStock(stockPackage!!)
-            else AppLinkCommands.restoreStock(stockPackage!!)
+            val stockCommands = if (enable) AppLinkCommands.disableStock(stockPackage)
+            else AppLinkCommands.restoreStock(stockPackage)
             onProgress(
                 if (enable) "Disabling links in $stockPackage..."
                 else "Re-enabling links in $stockPackage..."

--- a/src/main/kotlin/app/morphe/gui/util/DownloadUrlResolver.kt
+++ b/src/main/kotlin/app/morphe/gui/util/DownloadUrlResolver.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.net.HttpURLConnection
 import java.net.SocketTimeoutException
+import java.net.URI
 import java.net.URL
 
 object DownloadUrlResolver {
@@ -37,7 +38,7 @@ object DownloadUrlResolver {
         if (maxRedirectsToFollow <= 0) return url
 
         try {
-            val originalUrl = URL(url)
+            val originalUrl = URI(url).toURL()
             val connection = originalUrl.openConnection() as HttpURLConnection
             connection.instanceFollowRedirects = false
             connection.requestMethod = "HEAD"

--- a/src/main/kotlin/app/morphe/gui/util/Logger.kt
+++ b/src/main/kotlin/app/morphe/gui/util/Logger.kt
@@ -115,7 +115,7 @@ object Logger {
 
     private fun log(level: Level, message: String) {
         val timestamp = dateFormat.format(Date())
-        val logLine = "[$timestamp] [${level.name.padEnd(5)}] $message"
+        val logLine = "[$timestamp] [${level.name}] $message"
 
         // Print to console
         when (level) {

--- a/src/test/kotlin/app/morphe/desktop/command/PatchOptionsFileTest.kt
+++ b/src/test/kotlin/app/morphe/desktop/command/PatchOptionsFileTest.kt
@@ -132,6 +132,7 @@ class PatchOptionsFileTest {
         // patches (no compatibleWith) to default = false, so `default = true` is only
         // honored for app-specific patches.
         val adBlockPatch = rawResourcePatch(name = "AdBlocker", description = "Block Ads", default = true) {
+            @Suppress("DEPRECATION")
             compatibleWith("com.example.app")
         }
 


### PR DESCRIPTION
Cleans up compiler and deprecation warnings when building the JAR file, alongside bug fixes discovered while investigating the deprecations:

- `list-versions` now correctly reports app-specific patches that have no version targets (previously skipped by an erroneous guard condition).
- `list-versions --count-unused-patches=false` now correctly filters by `patch.default` instead of the deprecated `patch.use`, which always returned `false` in the new patcher and caused all patches to be excluded.
- License dialog link buttons now correctly open external websites in the browser (replacing non-functional Desktop browser calls with `LocalUriHandler`).
- Logger level tags now format without trailing space padding (e.g. `[INFO]` instead of `[INFO ]`).

Other changes are cosmetic maintenance to keep the build log clean.