### PR TITLE
feat: Add ProGuard jar shrinking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Cache Gradle
-        uses: burrunan/gradle-cache-action@v3
+      - name: Clean
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean --no-daemon
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,9 @@ dependencies {
     api(libs.morphe.patcher)
     implementation(libs.arsclib)
     implementation(libs.morphe.library)
-    implementation(libs.jadb)
+    implementation(libs.jadb) {
+        exclude(group = "org.mockito")
+    }
     implementation(libs.picocli)
 
     // -- Compose Desktop ---------------------------------------------------
@@ -177,6 +179,29 @@ tasks {
             "/prebuilt/*/aapt_*",
         )
 
+        // Exclude unused JNA native platforms to save ~5MB.
+        // We only support Mac (x64/arm64), Windows (x64), and Linux (x64/arm64).
+        exclude("com/sun/jna/aix-ppc/**")
+        exclude("com/sun/jna/aix-ppc64/**")
+        exclude("com/sun/jna/freebsd-x86/**")
+        exclude("com/sun/jna/freebsd-x86-64/**")
+        exclude("com/sun/jna/freebsd-aarch64/**")
+        exclude("com/sun/jna/dragonflybsd-x86-64/**")
+        exclude("com/sun/jna/openbsd-x86-64/**")
+        exclude("com/sun/jna/sunos-sparc/**")
+        exclude("com/sun/jna/sunos-sparcv9/**")
+        exclude("com/sun/jna/sunos-x86/**")
+        exclude("com/sun/jna/sunos-x86-64/**")
+        exclude("com/sun/jna/linux-arm/**")
+        exclude("com/sun/jna/linux-armel/**")
+        exclude("com/sun/jna/linux-mips64el/**")
+        exclude("com/sun/jna/linux-ppc/**")
+        exclude("com/sun/jna/linux-ppc64le/**")
+        exclude("com/sun/jna/linux-riscv64/**")
+        exclude("com/sun/jna/linux-s390x/**")
+        exclude("com/sun/jna/linux-loongarch64/**")
+        exclude("com/sun/jna/win32-x86/**")
+
         // NOTICE/LICENSE handling:
         //   * Global strategy is EXCLUDE (first-wins) so duplicates at non-transformed
         //     paths — including native libs like libskiko-*.dylib — are deduplicated.
@@ -241,8 +266,56 @@ tasks {
     }
 
     publish {
-        dependsOn(shadowJar)
+        dependsOn("overwriteShadowJar")
     }
+
+    assemble {
+        dependsOn("overwriteShadowJar")
+    }
+
+    val minifyShadowJar = register<proguard.gradle.ProGuardTask>("minifyShadowJar") {
+        // Only run when explicitly requested via assemble or direct call
+        enabled = gradle.startParameter.taskNames.any { it.contains("assemble") || it.contains("minify") || it.contains("publish") }
+        dependsOn(shadowJar)
+
+        // Use the JAR produced by shadowJar as input
+        val shadowJarFile = shadowJar.get().archiveFile.get().asFile
+        // Use a temporary file for the ProGuard output
+        val tempJarFile = file(shadowJarFile.absolutePath.replace(".jar", ".tmp.jar"))
+
+        injars(shadowJarFile)
+        outjars(tempJarFile)
+
+        // Load the Proguard configuration
+        configuration("proguard-rules.pro")
+
+        // Include the Java runtime classes
+        val javaHome = System.getProperty("java.home")
+        libraryjars("$javaHome/jmods")
+
+        // Report on what was removed
+        printusage(layout.buildDirectory.file("proguard/usage.txt").get().asFile)
+    }
+
+    val overwriteShadowJar = register("overwriteShadowJar") {
+        dependsOn(minifyShadowJar)
+        val shadowJarFile = shadowJar.get().archiveFile.get().asFile
+        val tempJarFile = file(shadowJarFile.absolutePath.replace(".jar", ".tmp.jar"))
+        
+        // Only run if minification actually happened
+        onlyIf { minifyShadowJar.get().enabled && tempJarFile.exists() }
+        
+        doLast {
+            tempJarFile.copyTo(shadowJarFile, overwrite = true)
+            tempJarFile.delete()
+        }
+    }
+
+    // Ensure all shadow-related tasks wait for minification to finish before using the JAR.
+    // This prevents "zip END header not found" errors caused by concurrent access.
+    named("shadowDistZip") { dependsOn(overwriteShadowJar) }
+    named("shadowDistTar") { dependsOn(overwriteShadowJar) }
+    named("startShadowScripts") { dependsOn(overwriteShadowJar) }
 }
 
 // ============================================================================

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
     // project must then apply the shadow plugin without a version to avoid
     // the "plugin is already on the classpath" conflict.
     implementation("com.gradleup.shadow:shadow-gradle-plugin:9.4.3")
+    implementation("com.guardsquare:proguard-gradle:7.9.1")
     implementation("org.jetbrains:annotations:26.1.0")
 }

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -1,0 +1,45 @@
+-dontobfuscate
+-dontoptimize
+-dontnote **
+-dontwarn **
+-ignorewarnings
+-keepattributes *Annotation*,InnerClasses,Signature,EnclosingMethod,SourceFile,LineNumberTable
+
+-keep class kotlin.** { *; }
+-keep class kotlinx.** { *; }
+-keep class org.jetbrains.skia.** { *; }
+-keep class org.jetbrains.skiko.** { *; }
+-keep class org.slf4j.nop.** { *; }
+
+# Bouncy Castle
+-keep class org.bouncycastle.jcajce.provider.** { *; }
+-keep class org.bouncycastle.jce.provider.** { *; }
+-keep class org.bouncycastle.crypto.prng.** { *; }
+-keep class * extends java.security.Provider
+-keep class * extends java.security.KeyStoreSpi
+
+-keep class app.morphe.** { *; }
+-keep class com.android.tools.smali.** { *; }
+-keep class com.android.apksig.** { *; }
+-keep class com.android.tools.build.apkzlib.** { *; }
+
+# Picocli (Command line parsing)
+-keep class picocli.** { *; }
+
+# Koin (Dependency Injection - uses reflection)
+-keep class org.koin.** { *; }
+
+# Ktor (Networking - uses reflection/ServiceLoader)
+-keep class io.ktor.** { *; }
+
+# JNA (Native access)
+#-keep class com.sun.jna.** { *; }
+
+# Keep SPI services (ServiceLoader)
+-keepnames class * {
+    public static <fields>;
+    public static <methods>;
+}
+-keepclassmembers class * {
+    @**.KoinInternalApi *;
+}


### PR DESCRIPTION
Adds ProGuard to reduce jar size

Before: **117mb**
After: **92mb**

ProGuard runs in `assemble` step.
If building locally and you want to skip the extra processing then instead run `./gradlew build`