### PR TITLE
feat: dynamically download GUI dependencies to reduce jar size

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,6 +173,10 @@ tasks {
     // Shadow JAR — the only distribution artifact
     // -------------------------------------------------------------------------
     shadowJar {
+        dependencies {
+            exclude(dependency("org.jetbrains.skiko:skiko-awt-runtime-.*:.*"))
+        }
+
         exclude(
             "/prebuilt/linux/aapt",
             "/prebuilt/windows/aapt.exe",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -175,6 +175,9 @@ tasks {
     shadowJar {
         dependencies {
             exclude(dependency("org.jetbrains.skiko:skiko-awt-runtime-.*:.*"))
+            exclude(dependency("org.jetbrains.compose.material:material-icons-extended-desktop:.*"))
+            exclude(dependency("net.java.dev.jna:jna:.*"))
+            exclude(dependency("net.java.dev.jna:jna-platform:.*"))
         }
 
         exclude(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import com.mikepenz.aboutlibraries.plugin.DuplicateMode
 import com.mikepenz.aboutlibraries.plugin.DuplicateRule
+import java.security.MessageDigest
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -28,6 +29,9 @@ kotlin {
     }
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
+    }
+    sourceSets.main {
+        kotlin.srcDir(layout.buildDirectory.dir("generated/source/bootstrap/main"))
     }
 }
 
@@ -63,6 +67,15 @@ repositories {
     maven { url = uri("https://jitpack.io") }
 }
 
+// ============================================================================
+// Bootstrap (GUI) Dependency Code Generation
+// ============================================================================
+val bootstrapDependencies = configurations.create("bootstrapDependencies") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    isTransitive = false
+}
+
 dependencies {
     api(libs.morphe.patcher)
     implementation(libs.arsclib)
@@ -71,6 +84,16 @@ dependencies {
         exclude(group = "org.mockito")
     }
     implementation(libs.picocli)
+
+    // -- Bootstrap (Code Generation) ---------------------------------------
+    bootstrapDependencies("org.jetbrains.compose.material:material-icons-extended-desktop:${libs.versions.materialIcons.get()}")
+    bootstrapDependencies("net.java.dev.jna:jna:${libs.versions.jna.get()}")
+    bootstrapDependencies("net.java.dev.jna:jna-platform:${libs.versions.jna.get()}")
+    bootstrapDependencies("org.jetbrains.skiko:skiko-awt-runtime-macos-x64:${libs.versions.skiko.get()}")
+    bootstrapDependencies("org.jetbrains.skiko:skiko-awt-runtime-macos-arm64:${libs.versions.skiko.get()}")
+    bootstrapDependencies("org.jetbrains.skiko:skiko-awt-runtime-linux-x64:${libs.versions.skiko.get()}")
+    bootstrapDependencies("org.jetbrains.skiko:skiko-awt-runtime-linux-arm64:${libs.versions.skiko.get()}")
+    bootstrapDependencies("org.jetbrains.skiko:skiko-awt-runtime-windows-x64:${libs.versions.skiko.get()}")
 
     // -- Compose Desktop ---------------------------------------------------
     // Platform-independent: single JAR runs on all supported OSes.
@@ -136,6 +159,64 @@ aboutLibraries {
 // Tasks
 // ============================================================================
 tasks {
+    val generateBootstrapConstants = register("generateBootstrapConstants") {
+        val artifactFiles = bootstrapDependencies.incoming.files
+        inputs.files(artifactFiles)
+        
+        val skikoVersion = libs.versions.skiko.get()
+        val materialIconsVersion = libs.versions.materialIcons.get()
+        val jnaVersion = libs.versions.jna.get()
+        
+        inputs.property("skikoVersion", skikoVersion)
+        inputs.property("materialIconsVersion", materialIconsVersion)
+        inputs.property("jnaVersion", jnaVersion)
+        
+        val outputDir = layout.buildDirectory.dir("generated/source/bootstrap/main/app/morphe/engine")
+        outputs.dir(outputDir)
+        
+        doLast {
+            val outDir = outputDir.get().asFile
+            outDir.mkdirs()
+            val outFile = File(outDir, "BootstrapConstants.kt")
+            
+            fun getHash(artifactName: String, version: String): String {
+                val exactName = "$artifactName-$version.jar"
+                val file = artifactFiles.find { it.name == exactName }
+                    ?: error("Could not find artifact exactly matching $exactName in ${artifactFiles.map { it.name }}")
+                val digest = MessageDigest.getInstance("SHA-256")
+                return digest.digest(file.readBytes()).joinToString("") { "%02x".format(it) }
+            }
+            
+            val content = """
+                package app.morphe.engine
+
+                internal object BootstrapConstants {
+                    const val SKIKO_VERSION = "$skikoVersion"
+                    const val MATERIAL_ICONS_VERSION = "$materialIconsVersion"
+                    const val JNA_VERSION = "$jnaVersion"
+                    
+                    const val MATERIAL_ICONS_HASH = "${getHash("material-icons-extended-desktop", materialIconsVersion)}"
+                    const val JNA_HASH = "${getHash("jna", jnaVersion)}"
+                    const val JNA_PLATFORM_HASH = "${getHash("jna-platform", jnaVersion)}"
+                    
+                    val SKIKO_HASHES = mapOf(
+                        "macos-x64" to "${getHash("skiko-awt-runtime-macos-x64", skikoVersion)}",
+                        "macos-arm64" to "${getHash("skiko-awt-runtime-macos-arm64", skikoVersion)}",
+                        "linux-x64" to "${getHash("skiko-awt-runtime-linux-x64", skikoVersion)}",
+                        "linux-arm64" to "${getHash("skiko-awt-runtime-linux-arm64", skikoVersion)}",
+                        "windows-x64" to "${getHash("skiko-awt-runtime-windows-x64", skikoVersion)}"
+                    )
+                }
+            """.trimIndent()
+            
+            outFile.writeText(content)
+        }
+    }
+
+    named("compileKotlin") {
+        dependsOn(generateBootstrapConstants)
+    }
+
     jar {
         manifest {
             attributes(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,10 @@ kotlinx-serialization = "1.11.0"
 # JNA (Windows DWM title bar tinting)
 jna = "5.19.1"
 
+# Bootstrap GUI
+skiko = "0.144.6"
+materialIcons = "1.7.3"
+
 # Testing
 mockk = "1.14.11"
 

--- a/src/main/kotlin/app/morphe/MorpheLauncher.kt
+++ b/src/main/kotlin/app/morphe/MorpheLauncher.kt
@@ -31,10 +31,11 @@ fun main(args: Array<String>) {
                 launchGuiReflectively(args)
                 return
             } else {
-                val skikoJar = BootstrapDownloader.downloadIfMissing()
+                val downloadedJars = BootstrapDownloader.downloadIfMissing()
                 val javaHome = System.getProperty("java.home")
                 val javaBin = File(javaHome, "bin/java").absolutePath
-                val classPath = File(location.toURI()).absolutePath + File.pathSeparator + skikoJar.absolutePath
+                val downloadedClassPath = downloadedJars.joinToString(File.pathSeparator) { it.absolutePath }
+                val classPath = File(location.toURI()).absolutePath + File.pathSeparator + downloadedClassPath
 
                 val processBuilder = ProcessBuilder(
                     javaBin,

--- a/src/main/kotlin/app/morphe/MorpheLauncher.kt
+++ b/src/main/kotlin/app/morphe/MorpheLauncher.kt
@@ -5,22 +5,67 @@
 
 package app.morphe
 
+import app.morphe.desktop.command.MainCommand
+import app.morphe.engine.BootstrapDownloader
 import app.morphe.library.logging.Logger
 import java.awt.GraphicsEnvironment
+import java.io.File
+import java.util.logging.Logger.getLogger as JVLogger
+import picocli.CommandLine
 
 fun main(args: Array<String>) {
-    if (args.isEmpty() && !GraphicsEnvironment.isHeadless()) {
-        app.morphe.gui.launchGui(args)
+    val isInternalGuiSubprocess = args.contains("--internal-gui-subprocess")
+    val isGuiIntent = (args.isEmpty() || isInternalGuiSubprocess) && !GraphicsEnvironment.isHeadless()
+
+    if (isGuiIntent) {
+        if (isInternalGuiSubprocess) {
+            val guiArgs = args.filter { it != "--internal-gui-subprocess" }.toTypedArray()
+            launchGuiReflectively(guiArgs)
+            return
+        } else {
+            val location = object {}.javaClass.protectionDomain.codeSource?.location
+            val isJar = location?.path?.endsWith(".jar") == true
+
+            if (!isJar) {
+                // Running from IDE/classpath, Skiko is likely already available
+                launchGuiReflectively(args)
+                return
+            } else {
+                val skikoJar = BootstrapDownloader.downloadIfMissing()
+                val javaHome = System.getProperty("java.home")
+                val javaBin = File(javaHome, "bin/java").absolutePath
+                val classPath = File(location.toURI()).absolutePath + File.pathSeparator + skikoJar.absolutePath
+
+                val processBuilder = ProcessBuilder(
+                    javaBin,
+                    "-cp",
+                    classPath,
+                    "app.morphe.MorpheLauncherKt",
+                    "--internal-gui-subprocess",
+                    *args
+                )
+                processBuilder.inheritIO()
+                val process = processBuilder.start()
+                process.waitFor()
+                System.exit(process.exitValue())
+            }
+        }
     } else {
         Logger.setDefault()
 
-        if (GraphicsEnvironment.isHeadless()){
-            val logger = java.util.logging.Logger.getLogger("app.morphe.MorpheLauncher")
+        if (GraphicsEnvironment.isHeadless() && args.isEmpty()){
+            val logger = JVLogger("app.morphe.MorpheLauncher")
             logger.info("Running in Headless environment, falling back to CLI mode.")
         }
 
-        picocli.CommandLine(app.morphe.desktop.command.MainCommand)
+        CommandLine(MainCommand)
             .execute(*args)
             .let(System::exit)
     }
+}
+
+private fun launchGuiReflectively(args: Array<String>) {
+    Class.forName("app.morphe.gui.GuiMainKt")
+        .getMethod("launchGui", Array<String>::class.java)
+        .invoke(null, args)
 }

--- a/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
+++ b/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine
+
+import java.io.File
+import java.io.FileOutputStream
+import java.net.URI
+import java.security.MessageDigest
+import java.util.logging.Logger
+
+/**
+ * Handles deferred downloading of GUI dependencies (Skiko) to keep the base CLI small.
+ */
+object BootstrapDownloader {
+    private val logger = Logger.getLogger("app.morphe.engine.BootstrapDownloader")
+
+    private const val SKIKO_VERSION = "0.144.6"
+    
+    // Hardcoded expected SHA-256 hashes for Skiko 0.144.6 targets to ensure supply-chain security
+    private val EXPECTED_HASHES = mapOf(
+        "macos-x64" to "aacb31a5d2a70197abe18f9e81698eef15c83435791d4c487a2ffe139913762e",
+        "macos-arm64" to "aec37b44e8dabf4de620068146769655748be3971bf868614e5ec6b240b2ac35",
+        "linux-x64" to "3ed16be373ccbba7fbdca9acd7747ff2ed3d441764ac070aa20682c84764a671",
+        "linux-arm64" to "313082bbc829dc09664f9bde09b18b668396a57522f43279e373c1a67198419f",
+        "windows-x64" to "91fe81d4fa508d9a00c4596a6f23adc7e4ce193d0687afc83a486048d3f276f0"
+    )
+
+    /**
+     * Downloads the Skiko JAR for the current platform if it's missing or invalid.
+     * @return the downloaded (or cached) Skiko JAR file.
+     */
+    fun downloadIfMissing(): File {
+        val targetName = PlatformDetector.skikoTargetName
+        val expectedHash = EXPECTED_HASHES[targetName] 
+            ?: error("Unsupported or unknown Skiko target: $targetName")
+
+        val fileName = "skiko-awt-runtime-$targetName-$SKIKO_VERSION.jar"
+        val binDir = File(MorpheData.root, "bin/skiko").also { it.mkdirs() }
+        val targetFile = File(binDir, fileName)
+
+        if (targetFile.exists()) {
+            logger.info("Verifying cached GUI dependencies ($targetName)...")
+            if (verifyHash(targetFile, expectedHash)) {
+                logger.info("Cache valid.")
+                return targetFile
+            } else {
+                logger.warning("Cache invalid, redownloading.")
+                targetFile.delete()
+            }
+        }
+
+        val url = "https://repo1.maven.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-$targetName/$SKIKO_VERSION/$fileName"
+        logger.info("Downloading GUI dependencies for $targetName...")
+
+        try {
+            URI(url).toURL().openStream().use { input ->
+                FileOutputStream(targetFile).use { output ->
+                    input.copyTo(output)
+                }
+            }
+        } catch (e: Exception) {
+            targetFile.delete()
+            logger.severe("Failed to download GUI dependencies: ${e.message}")
+            kotlin.system.exitProcess(1)
+        }
+
+        logger.info("Verifying checksums...")
+        if (!verifyHash(targetFile, expectedHash)) {
+            targetFile.delete()
+            logger.severe("Checksum mismatch for downloaded Skiko JAR.")
+            kotlin.system.exitProcess(1)
+        }
+
+        logger.info("GUI dependencies ready.")
+        return targetFile
+    }
+
+    private fun verifyHash(file: File, expectedHash: String): Boolean {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { fis ->
+            val buffer = ByteArray(8192)
+            var read: Int
+            while (fis.read(buffer).also { read = it } != -1) {
+                digest.update(buffer, 0, read)
+            }
+        }
+        val actualHash = digest.digest().joinToString("") { "%02x".format(it) }
+        return actualHash.equals(expectedHash, ignoreCase = true)
+    }
+}

--- a/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
+++ b/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
@@ -17,55 +17,38 @@ import java.util.logging.Logger
 object BootstrapDownloader {
     private val logger = Logger.getLogger("app.morphe.engine.BootstrapDownloader")
 
-    // Versions
-    private const val SKIKO_VERSION = "0.144.6"
-    private const val MATERIAL_ICONS_VERSION = "1.7.3"
-    private const val JNA_VERSION = "5.19.1"
-
-    // Hashes (SHA-256 supply-chain security)
-    private const val MATERIAL_ICONS_HASH = "dc55d383dca8279e353917e5c5a93d192a95e7ca4f926ee55ee0b4627f99d860"
-    private const val JNA_HASH = "4fb141dd8ef6b0585ffceea4bc49602fbc6312fa977e2c488794ea3e6aafecae"
-    private const val JNA_PLATFORM_HASH = "3b3864f5b449e9c3c24b16861524b622b086563f44e0cd8384c8efc5a6052f82"
-    private val SKIKO_HASHES = mapOf(
-        "macos-x64" to "aacb31a5d2a70197abe18f9e81698eef15c83435791d4c487a2ffe139913762e",
-        "macos-arm64" to "aec37b44e8dabf4de620068146769655748be3971bf868614e5ec6b240b2ac35",
-        "linux-x64" to "3ed16be373ccbba7fbdca9acd7747ff2ed3d441764ac070aa20682c84764a671",
-        "linux-arm64" to "313082bbc829dc09664f9bde09b18b668396a57522f43279e373c1a67198419f",
-        "windows-x64" to "91fe81d4fa508d9a00c4596a6f23adc7e4ce193d0687afc83a486048d3f276f0"
-    )
-
     // Remote Dependencies
     data class RemoteDependency(val fileName: String, val url: String, val expectedHash: String)
 
     private val SKIKO by lazy {
         val targetName = PlatformDetector.skikoTargetName
-        val skikoHash = SKIKO_HASHES[targetName] 
+        val skikoHash = BootstrapConstants.SKIKO_HASHES[targetName] 
             ?: error("Unsupported or unknown Skiko target: $targetName")
         
-        val skikoFileName = "skiko-awt-runtime-$targetName-$SKIKO_VERSION.jar"
+        val skikoFileName = "skiko-awt-runtime-$targetName-${BootstrapConstants.SKIKO_VERSION}.jar"
         RemoteDependency(
             fileName = skikoFileName,
-            url = "https://repo1.maven.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-$targetName/$SKIKO_VERSION/$skikoFileName",
+            url = "https://repo1.maven.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-$targetName/${BootstrapConstants.SKIKO_VERSION}/$skikoFileName",
             expectedHash = skikoHash
         )
     }
 
     private val MATERIAL_ICONS = RemoteDependency(
-        fileName = "material-icons-extended-desktop-$MATERIAL_ICONS_VERSION.jar",
-        url = "https://repo1.maven.org/maven2/org/jetbrains/compose/material/material-icons-extended-desktop/$MATERIAL_ICONS_VERSION/material-icons-extended-desktop-$MATERIAL_ICONS_VERSION.jar",
-        expectedHash = MATERIAL_ICONS_HASH
+        fileName = "material-icons-extended-desktop-${BootstrapConstants.MATERIAL_ICONS_VERSION}.jar",
+        url = "https://repo1.maven.org/maven2/org/jetbrains/compose/material/material-icons-extended-desktop/${BootstrapConstants.MATERIAL_ICONS_VERSION}/material-icons-extended-desktop-${BootstrapConstants.MATERIAL_ICONS_VERSION}.jar",
+        expectedHash = BootstrapConstants.MATERIAL_ICONS_HASH
     )
 
     private val JNA = RemoteDependency(
-        fileName = "jna-$JNA_VERSION.jar",
-        url = "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$JNA_VERSION/jna-$JNA_VERSION.jar",
-        expectedHash = JNA_HASH
+        fileName = "jna-${BootstrapConstants.JNA_VERSION}.jar",
+        url = "https://repo1.maven.org/maven2/net/java/dev/jna/jna/${BootstrapConstants.JNA_VERSION}/jna-${BootstrapConstants.JNA_VERSION}.jar",
+        expectedHash = BootstrapConstants.JNA_HASH
     )
 
     private val JNA_PLATFORM = RemoteDependency(
-        fileName = "jna-platform-$JNA_VERSION.jar",
-        url = "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/$JNA_VERSION/jna-platform-$JNA_VERSION.jar",
-        expectedHash = JNA_PLATFORM_HASH
+        fileName = "jna-platform-${BootstrapConstants.JNA_VERSION}.jar",
+        url = "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/${BootstrapConstants.JNA_VERSION}/jna-platform-${BootstrapConstants.JNA_VERSION}.jar",
+        expectedHash = BootstrapConstants.JNA_PLATFORM_HASH
     )
 
     /**

--- a/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
+++ b/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
@@ -12,15 +12,21 @@ import java.security.MessageDigest
 import java.util.logging.Logger
 
 /**
- * Handles deferred downloading of GUI dependencies (Skiko) to keep the base CLI small.
+ * Handles deferred downloading of GUI dependencies to keep the base CLI as small as possible.
  */
 object BootstrapDownloader {
     private val logger = Logger.getLogger("app.morphe.engine.BootstrapDownloader")
 
+    // Versions
     private const val SKIKO_VERSION = "0.144.6"
-    
-    // Hardcoded expected SHA-256 hashes for Skiko 0.144.6 targets to ensure supply-chain security
-    private val EXPECTED_HASHES = mapOf(
+    private const val MATERIAL_ICONS_VERSION = "1.7.3"
+    private const val JNA_VERSION = "5.19.1"
+
+    // Hashes (SHA-256 supply-chain security)
+    private const val MATERIAL_ICONS_HASH = "dc55d383dca8279e353917e5c5a93d192a95e7ca4f926ee55ee0b4627f99d860"
+    private const val JNA_HASH = "4fb141dd8ef6b0585ffceea4bc49602fbc6312fa977e2c488794ea3e6aafecae"
+    private const val JNA_PLATFORM_HASH = "3b3864f5b449e9c3c24b16861524b622b086563f44e0cd8384c8efc5a6052f82"
+    private val SKIKO_HASHES = mapOf(
         "macos-x64" to "aacb31a5d2a70197abe18f9e81698eef15c83435791d4c487a2ffe139913762e",
         "macos-arm64" to "aec37b44e8dabf4de620068146769655748be3971bf868614e5ec6b240b2ac35",
         "linux-x64" to "3ed16be373ccbba7fbdca9acd7747ff2ed3d441764ac070aa20682c84764a671",
@@ -28,54 +34,86 @@ object BootstrapDownloader {
         "windows-x64" to "91fe81d4fa508d9a00c4596a6f23adc7e4ce193d0687afc83a486048d3f276f0"
     )
 
-    /**
-     * Downloads the Skiko JAR for the current platform if it's missing or invalid.
-     * @return the downloaded (or cached) Skiko JAR file.
-     */
-    fun downloadIfMissing(): File {
+    // Remote Dependencies
+    data class RemoteDependency(val fileName: String, val url: String, val expectedHash: String)
+
+    private val SKIKO by lazy {
         val targetName = PlatformDetector.skikoTargetName
-        val expectedHash = EXPECTED_HASHES[targetName] 
+        val skikoHash = SKIKO_HASHES[targetName] 
             ?: error("Unsupported or unknown Skiko target: $targetName")
+        
+        val skikoFileName = "skiko-awt-runtime-$targetName-$SKIKO_VERSION.jar"
+        RemoteDependency(
+            fileName = skikoFileName,
+            url = "https://repo1.maven.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-$targetName/$SKIKO_VERSION/$skikoFileName",
+            expectedHash = skikoHash
+        )
+    }
 
-        val fileName = "skiko-awt-runtime-$targetName-$SKIKO_VERSION.jar"
-        val binDir = File(MorpheData.root, "bin/skiko").also { it.mkdirs() }
-        val targetFile = File(binDir, fileName)
+    private val MATERIAL_ICONS = RemoteDependency(
+        fileName = "material-icons-extended-desktop-$MATERIAL_ICONS_VERSION.jar",
+        url = "https://repo1.maven.org/maven2/org/jetbrains/compose/material/material-icons-extended-desktop/$MATERIAL_ICONS_VERSION/material-icons-extended-desktop-$MATERIAL_ICONS_VERSION.jar",
+        expectedHash = MATERIAL_ICONS_HASH
+    )
 
-        if (targetFile.exists()) {
-            logger.info("Verifying cached GUI dependencies ($targetName)...")
-            if (verifyHash(targetFile, expectedHash)) {
-                logger.info("Cache valid.")
-                return targetFile
-            } else {
-                logger.warning("Cache invalid, redownloading.")
-                targetFile.delete()
-            }
-        }
+    private val JNA = RemoteDependency(
+        fileName = "jna-$JNA_VERSION.jar",
+        url = "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$JNA_VERSION/jna-$JNA_VERSION.jar",
+        expectedHash = JNA_HASH
+    )
 
-        val url = "https://repo1.maven.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-$targetName/$SKIKO_VERSION/$fileName"
-        logger.info("Downloading GUI dependencies for $targetName...")
+    private val JNA_PLATFORM = RemoteDependency(
+        fileName = "jna-platform-$JNA_VERSION.jar",
+        url = "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/$JNA_VERSION/jna-platform-$JNA_VERSION.jar",
+        expectedHash = JNA_PLATFORM_HASH
+    )
 
-        try {
-            URI(url).toURL().openStream().use { input ->
-                FileOutputStream(targetFile).use { output ->
-                    input.copyTo(output)
+    /**
+     * Downloads the required GUI dependencies if missing or invalid.
+     * @return the list of downloaded (or cached) dependency files.
+     */
+    fun downloadIfMissing(): List<File> {
+        val dependencies = listOf(SKIKO, MATERIAL_ICONS, JNA, JNA_PLATFORM)
+        val binDir = File(MorpheData.root, "libs").also { it.mkdirs() }
+        val downloadedFiles = mutableListOf<File>()
+
+        for (dep in dependencies) {
+            val targetFile = File(binDir, dep.fileName)
+
+            if (targetFile.exists()) {
+                if (verifyHash(targetFile, dep.expectedHash)) {
+                    downloadedFiles.add(targetFile)
+                    continue
+                } else {
+                    logger.warning("Cache invalid for ${dep.fileName}, redownloading.")
+                    targetFile.delete()
                 }
             }
-        } catch (e: Exception) {
-            targetFile.delete()
-            logger.severe("Failed to download GUI dependencies: ${e.message}")
-            kotlin.system.exitProcess(1)
+
+            logger.info("Downloading ${dep.fileName}...")
+            try {
+                URI(dep.url).toURL().openStream().use { input ->
+                    FileOutputStream(targetFile).use { output ->
+                        input.copyTo(output)
+                    }
+                }
+            } catch (e: Exception) {
+                targetFile.delete()
+                logger.severe("Failed to download GUI dependency ${dep.fileName}: ${e.message}")
+                kotlin.system.exitProcess(1)
+            }
+
+            if (!verifyHash(targetFile, dep.expectedHash)) {
+                targetFile.delete()
+                logger.severe("Checksum mismatch for downloaded dependency ${dep.fileName}.")
+                kotlin.system.exitProcess(1)
+            }
+
+            downloadedFiles.add(targetFile)
         }
 
-        logger.info("Verifying checksums...")
-        if (!verifyHash(targetFile, expectedHash)) {
-            targetFile.delete()
-            logger.severe("Checksum mismatch for downloaded Skiko JAR.")
-            kotlin.system.exitProcess(1)
-        }
-
-        logger.info("GUI dependencies ready.")
-        return targetFile
+        logger.info("All GUI dependencies ready.")
+        return downloadedFiles
     }
 
     private fun verifyHash(file: File, expectedHash: String): Boolean {

--- a/src/main/kotlin/app/morphe/engine/PlatformDetector.kt
+++ b/src/main/kotlin/app/morphe/engine/PlatformDetector.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-desktop
+ */
+
+package app.morphe.engine
+
+/**
+ * Utility to determine the host OS and architecture for resolving platform-specific dependencies.
+ */
+object PlatformDetector {
+    /**
+     * The Skiko target name string based on the current platform and architecture.
+     * Examples: macos-arm64, windows-x64, linux-x64
+     */
+    val skikoTargetName: String by lazy {
+        val osName = System.getProperty("os.name").lowercase()
+        val osArch = System.getProperty("os.arch").lowercase()
+
+        val isMac = osName.contains("mac")
+        val isWindows = osName.contains("windows")
+        val isLinux = osName.contains("linux")
+
+        val isArm = osArch == "aarch64" || osArch == "arm64"
+        val isX64 = osArch == "amd64" || osArch == "x86_64"
+
+        when {
+            isMac && isArm -> "macos-arm64"
+            isMac && isX64 -> "macos-x64"
+            isLinux && isArm -> "linux-arm64"
+            isLinux && isX64 -> "linux-x64"
+            isWindows && isX64 -> "windows-x64"
+            else -> error("Unsupported OS/Architecture combination: $osName / $osArch")
+        }
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Launching the GUI for the very first time will now require an active internet connection to download the platform-specific Skiko binaries, JNA, and Material Icons. The downloaded JARs are verified via SHA-256 hashes and cached locally for all subsequent runs.

---

Reduces the base CLI executable size by excluding Skiko native libraries, JNA binaries, and the massive Material Icons library from the fat jar. These heavy dependencies are dynamically downloaded on-demand when the GUI is launched. This significantly decreases the application footprint (`111.8 MB` -> `59.0 MB`) for users who only need the CLI.

Closes #110, #150.

*This implementation is functionally complete and has been tested on Linux x64. I was unable to thoroughly test the GUI loading behavior on Windows or macOS due to lack of time, but the underlying cross-platform OS detection, downloading, and classpath injection logic is fully implemented.*