### PR TITLE
fix: Clean up obsolete GUI dependencies

### DIFF
--- a/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
+++ b/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
@@ -58,6 +58,15 @@ object BootstrapDownloader {
     fun downloadIfMissing(): List<File> {
         val dependencies = listOf(SKIKO, MATERIAL_ICONS, JNA, JNA_PLATFORM)
         val binDir = File(MorpheData.root, "libs").also { it.mkdirs() }
+        
+        val expectedFileNames = dependencies.map { it.fileName }.toSet()
+        binDir.listFiles()?.forEach { file ->
+            if (file.isFile && file.name !in expectedFileNames) {
+                logger.info("Removing obsolete dependency: ${file.name}")
+                file.delete()
+            }
+        }
+        
         val downloadedFiles = mutableListOf<File>()
 
         for (dep in dependencies) {


### PR DESCRIPTION
Quick follow-up to #232.

Fixes an edge case where old versions of Skiko or JNA JARs were orphaned and left in the `libs/` directory after a version bump or downgrade, taking up unnecessary disk space. The `BootstrapDownloader` now runs an automatic garbage-collection pass on startup to delete any unrecognized or outdated dependency files before downloading new ones.
