### PR TITLE
fix: Add Enable-Native-Access attribute to jar manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -221,7 +221,7 @@ tasks {
         manifest {
             attributes(
                 "Implementation-Title" to project.name,
-                "Implementation-Version" to project.version
+                "Implementation-Version" to project.version,
                 "Enable-Native-Access" to "ALL-UNNAMED"
             )
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -222,6 +222,7 @@ tasks {
             attributes(
                 "Implementation-Title" to project.name,
                 "Implementation-Version" to project.version
+                "Enable-Native-Access" to "ALL-UNNAMED"
             )
         }
     }


### PR DESCRIPTION
Add Enable-Native-Access: ALL-UNNAMED to the manifest of an executable JAR file.

With this added, no need to add `--enable-native-access ALL-UNNAMED` flag when running the jar file