### PR TITLE
fix: move both HTTP clients to OkHttp for parity with manager

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,7 @@ dependencies {
 
     // -- Networking (GUI) --------------------------------------------------
     implementation(libs.ktor.client.core)
-    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.client.logging)
@@ -353,6 +353,11 @@ tasks {
             // Ktor uses ServiceLoader
             exclude(dependency("io.ktor:.*"))
             exclude(dependency("org.slf4j:.*"))
+            // OkHttp (Ktor's engine) picks its TLS platform reflectively at startup and
+            // okio backs its IO. Keep both whole so minimize can't prune a platform class
+            // that is only ever reached by name.
+            exclude(dependency("com.squareup.okhttp3:.*"))
+            exclude(dependency("com.squareup.okio:.*"))
             // Koin uses reflection
             exclude(dependency("io.insert-koin:.*"))
             // Coroutines Swing provides Dispatchers.Main via ServiceLoader

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -353,9 +353,6 @@ tasks {
             // Ktor uses ServiceLoader
             exclude(dependency("io.ktor:.*"))
             exclude(dependency("org.slf4j:.*"))
-            // OkHttp (Ktor's engine) picks its TLS platform reflectively at startup and
-            // okio backs its IO. Keep both whole so minimize can't prune a platform class
-            // that is only ever reached by name.
             exclude(dependency("com.squareup.okhttp3:.*"))
             exclude(dependency("com.squareup.okio:.*"))
             // Koin uses reflection

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ jadb = { module = "app.morphe:jadb", version.ref = "jadb" }
 
 # Ktor Client
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }

--- a/src/main/kotlin/app/morphe/desktop/command/CliHttpClient.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/CliHttpClient.kt
@@ -6,11 +6,14 @@
 package app.morphe.desktop.command
 
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import okhttp3.Dns
+import okhttp3.Protocol
+import java.net.Inet4Address
 
 /**
  * Lazy initialized HttpClient for CLI commands. One client per process is fine for short-lived
@@ -20,20 +23,32 @@ import kotlinx.serialization.json.Json
  */
 object CliHttpClient {
     val instance: HttpClient by lazy {
-        HttpClient(CIO) {
+        HttpClient(OkHttp) {
+            engine {
+                config {
+                    // Prefer IPv4 so an advertised but unroutable IPv6 address does not
+                    // burn the connect timeout before the working A record is tried.
+                    dns { hostname ->
+                        val all = Dns.SYSTEM.lookup(hostname)
+                        all.filterIsInstance<Inet4Address>().ifEmpty { all }
+                    }
+                    // Pin HTTP/1.1 to avoid intermittent HTTP/2 stream resets against
+                    // GitHub-backed download endpoints.
+                    protocols(listOf(Protocol.HTTP_1_1))
+                    followRedirects(true)
+                    followSslRedirects(true)
+                }
+            }
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
             }
             // Idle/socket timeouts (not a total cap) so large .mpp downloads don't fail
-            // for being big. Only genuine stalls or issues fail. Default CIO requestTimeout is 15s.
+            // for being big. Only genuine stalls or issues fail.
             install(HttpTimeout) {
                 connectTimeoutMillis = 30_000
                 socketTimeoutMillis = 60_000
             }
             // Retry/429 handling lives in HttpService (single layer), not a client plugin.
-            engine {
-                requestTimeout = 0
-            }
         }
     }
 }

--- a/src/main/kotlin/app/morphe/gui/di/AppModule.kt
+++ b/src/main/kotlin/app/morphe/gui/di/AppModule.kt
@@ -12,13 +12,16 @@ import app.morphe.gui.data.repository.UpdateCheckRepository
 import app.morphe.engine.PatchedAppStore
 import app.morphe.gui.util.PatchService
 import io.ktor.client.*
-import io.ktor.client.engine.cio.*
+import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import okhttp3.Dns
+import okhttp3.Protocol
 import org.koin.dsl.module
+import java.net.Inet4Address
 import app.morphe.gui.ui.screens.home.HomeViewModel
 import app.morphe.gui.ui.screens.patches.PatchesViewModel
 import app.morphe.gui.ui.screens.patches.PatchSelectionViewModel
@@ -41,7 +44,23 @@ val appModule = module {
 
     // Ktor HTTP Client
     single {
-        HttpClient(CIO) {
+        HttpClient(OkHttp) {
+            engine {
+                config {
+                    // Prefer IPv4. A host with an advertised but unroutable IPv6
+                    // address otherwise burns the whole connect timeout before
+                    // anything tries the working A record.
+                    dns { hostname ->
+                        val all = Dns.SYSTEM.lookup(hostname)
+                        all.filterIsInstance<Inet4Address>().ifEmpty { all }
+                    }
+                    // Pin HTTP/1.1. Avoids intermittent HTTP/2 PROTOCOL_ERROR stream
+                    // resets seen against GitHub-backed download endpoints.
+                    protocols(listOf(Protocol.HTTP_1_1))
+                    followRedirects(true)
+                    followSslRedirects(true)
+                }
+            }
             install(ContentNegotiation) {
                 json(get())
             }
@@ -61,10 +80,6 @@ val appModule = module {
                 socketTimeoutMillis = 60_000
             }
             // Retry/429 handling lives in HttpService (single layer). Not a client plugin, to avoid compounding retries.
-            engine {
-                // Disable the engine-level total-call cap; the timeouts above govern.
-                requestTimeout = 0
-            }
         }
     }
 


### PR DESCRIPTION
- Adding a github patch source could sometimes crash. Switching to OkHttp solves this issue and brings it to parity with manager.