### PR TITLE
fix: Preserve manifest attributes in minimized jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -284,6 +284,12 @@ tasks {
     // Shadow JAR — the only distribution artifact
     // ============================================================================
     shadowJar {
+        manifest {
+            attributes(
+                "Enable-Native-Access" to "ALL-UNNAMED"
+            )
+        }
+
         dependencies {
             exclude(dependency("org.jetbrains.skiko:skiko-awt-runtime-.*:.*"))
             exclude(dependency("net.java.dev.jna:jna:.*"))


### PR DESCRIPTION
### Bug Fix: Explicitly map JVM Manifest attributes to ShadowJar

#### Context / Problem
When running the built executable application via `java -jar morphe-desktop-1.13.0-all.jar`, the JVM triggers warnings stating `WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module`.

While we had `Enable-Native-Access: ALL-UNNAMED` declared inside the standard `jar` task configuration block, the Gradle Shadow Plugin (`com.gradleup.shadow`) generates its own isolated manifest scope for the final fat/minified distribution artifact. Because we use the `application` plugin alongside down-stream ProGuard/minification routines, the standard manifest attributes were failing to properly inherit/merge down to the final artifact.

#### Solution
Following the [Gradleup Shadow Manifest Configuration Guidelines](https://gradleup.com/shadow/configuration/), I have explicitly assigned the requisite `MANIFEST.MF` properties (the `Enable-Native-Access`) directly into the `shadowJar` task block.

This ensures that the required flag is hardcoded into the final compiled archive, removing runtime console spam without requiring users to append manual execution flags.

#### Verification
Checked compiled artifact via:
`jar xf build/libs/morphe-desktop-all.jar META-INF/MANIFEST.MF && cat META-INF/MANIFEST.MF`
- Confirmed properties are written properly.
- Confirmed `java -jar` executes without native-access warnings.

The version of jre that I use:
```
java --version
openjdk 26.0.2 2026-07-21
OpenJDK Runtime Environment Zulu26.32+13-CA (build 26.0.2+10)
OpenJDK 64-Bit Server VM Zulu26.32+13-CA (build 26.0.2+10, mixed mode, sharing)
```