### PR TITLE
feat: Show version codes in `list-versions` and `list-patches`

### DIFF
--- a/src/main/kotlin/app/morphe/desktop/command/ListCompatibleVersions.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/ListCompatibleVersions.kt
@@ -8,6 +8,7 @@ package app.morphe.desktop.command
 import app.morphe.desktop.command.CliHttpClient
 import app.morphe.engine.VersionMap
 import app.morphe.engine.mostCommonCompatibleVersions
+import app.morphe.engine.versionCodesFor
 import app.morphe.patcher.patch.loadPatchesFromJar
 import picocli.CommandLine
 import picocli.CommandLine.Command
@@ -87,13 +88,7 @@ internal class ListCompatibleVersions : Runnable {
         val patches = loadPatchesFromJar(patchesFiles)
 
         fun getVersionCodesString(pkgName: String, versionName: String): String {
-            val target = patches
-                .flatMap { it.compatibility.orEmpty() }
-                .filter { it.packageName == pkgName }
-                .flatMap { it.targets }
-                .find { it.version == versionName && !it.versionCodes.isNullOrEmpty() }
-
-            return target?.versionCodes?.let { codes ->
+            return patches.versionCodesFor(pkgName, versionName)?.let { codes ->
                 " [versionCodes: " + codes.entries.joinToString(", ") { "${it.key.name}=${it.value}" } + "]"
             } ?: ""
         }

--- a/src/main/kotlin/app/morphe/desktop/command/ListCompatibleVersions.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/ListCompatibleVersions.kt
@@ -71,24 +71,6 @@ internal class ListCompatibleVersions : Runnable {
     private lateinit var spec: CommandSpec
 
     override fun run() {
-        fun VersionMap.buildVersionsString(): String {
-            if (isEmpty()) return "Any"
-
-            fun buildPatchesCountString(count: Int) = if (count == 1) "1 patch" else "$count patches"
-
-            return entries.joinToString("\n") { (version, count) ->
-                "$version (${buildPatchesCountString(count)})"
-            }
-        }
-
-        fun buildString(entry: Map.Entry<String, VersionMap>) =
-            buildString {
-                val (name, versions) = entry
-                appendLine("Package name: $name")
-                appendLine("Most common compatible versions:")
-                appendLine(versions.buildVersionsString().prependIndent("\t"))
-            }
-
         try {
             patchesFiles = PatchFileResolver.resolve(
                 patchesFiles,
@@ -103,6 +85,37 @@ internal class ListCompatibleVersions : Runnable {
         }
 
         val patches = loadPatchesFromJar(patchesFiles)
+
+        fun getVersionCodesString(pkgName: String, versionName: String): String {
+            val target = patches
+                .flatMap { it.compatibility.orEmpty() }
+                .filter { it.packageName == pkgName }
+                .flatMap { it.targets }
+                .find { it.version == versionName && !it.versionCodes.isNullOrEmpty() }
+
+            return target?.versionCodes?.let { codes ->
+                " [versionCodes: " + codes.entries.joinToString(", ") { "${it.key.name}=${it.value}" } + "]"
+            } ?: ""
+        }
+
+        fun VersionMap.buildVersionsString(packageName: String): String {
+            if (isEmpty()) return "Any"
+
+            fun buildPatchesCountString(count: Int) = if (count == 1) "1 patch" else "$count patches"
+
+            return entries.joinToString("\n") { (version, count) ->
+                val versionCodesStr = getVersionCodesString(packageName, version)
+                "$version$versionCodesStr (${buildPatchesCountString(count)})"
+            }
+        }
+
+        fun buildString(entry: Map.Entry<String, VersionMap>) =
+            buildString {
+                val (name, versions) = entry
+                appendLine("Package name: $name")
+                appendLine("Most common compatible versions:")
+                appendLine(versions.buildVersionsString(name).prependIndent("\t"))
+            }
 
         patches.mostCommonCompatibleVersions(
             packageNames,

--- a/src/main/kotlin/app/morphe/desktop/command/ListPatchesCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/ListPatchesCommand.kt
@@ -133,6 +133,17 @@ internal object ListPatchesCommand : Runnable {
                 append("\nType: $type")
             }
 
+        fun getVersionCodesString(patch: Patch<*>, pkgName: String, versionName: String): String {
+            val target = patch.compatibility.orEmpty()
+                .filter { it.packageName == pkgName }
+                .flatMap { it.targets }
+                .find { it.version == versionName && !it.versionCodes.isNullOrEmpty() }
+
+            return target?.versionCodes?.let { codes ->
+                codes.entries.joinToString(", ") { "${it.key.name}=${it.value}" }
+            } ?: ""
+        }
+
         fun IndexedValue<Patch<*>>.buildString() =
             let { (index, patch) ->
                 buildString {
@@ -162,14 +173,24 @@ internal object ListPatchesCommand : Runnable {
                                     buildString {
                                         val displayName = name ?: "(universal)"
                                         if (withVersions && versions.isNotEmpty()) {
-                                            appendLine("Package name: $displayName")
-                                            appendLine("Compatible versions:")
-                                            append(versions.joinToString("\n").prependIndent("\t"))
+                                            appendLine("\tPackage name: $displayName")
+                                            appendLine("\tCompatible versions:")
+                                            append(versions.joinToString("\n").prependIndent("\t\t"))
+
+                                            val codesList = versions.mapNotNull { v ->
+                                                val codes = getVersionCodesString(patch, displayName, v)
+                                                if (codes.isNotEmpty()) "$v: $codes" else null
+                                            }
+
+                                            if (codesList.isNotEmpty()) {
+                                                append("\n\tVersion codes:\n")
+                                                append(codesList.joinToString("\n").prependIndent("\t\t"))
+                                            }
                                         } else {
-                                            append("Package name: $displayName")
+                                            append("\tPackage name: $displayName")
                                         }
                                     }
-                                }.prependIndent("\t"),
+                                },
                             )
                         }
                     }

--- a/src/main/kotlin/app/morphe/desktop/command/ListPatchesCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/ListPatchesCommand.kt
@@ -11,6 +11,7 @@ package app.morphe.desktop.command
 import app.morphe.desktop.command.CliHttpClient
 import app.morphe.engine.compatibleVersionsForDisplay
 import app.morphe.engine.isCompatibleWith
+import app.morphe.engine.versionCodesFor
 import app.morphe.patcher.patch.Patch
 import app.morphe.patcher.patch.loadPatchesFromJar
 import picocli.CommandLine
@@ -134,12 +135,7 @@ internal object ListPatchesCommand : Runnable {
             }
 
         fun getVersionCodesString(patch: Patch<*>, pkgName: String, versionName: String): String {
-            val target = patch.compatibility.orEmpty()
-                .filter { it.packageName == pkgName }
-                .flatMap { it.targets }
-                .find { it.version == versionName && !it.versionCodes.isNullOrEmpty() }
-
-            return target?.versionCodes?.let { codes ->
+            return patch.versionCodesFor(pkgName, versionName)?.let { codes ->
                 codes.entries.joinToString(", ") { "${it.key.name}=${it.value}" }
             } ?: ""
         }

--- a/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
@@ -6,10 +6,29 @@
 package app.morphe.engine
 
 import app.morphe.patcher.patch.Patch
+import app.morphe.patcher.patch.SupportedAbi
 
 typealias VersionMap = LinkedHashMap<String, Int>
 typealias CompatibleVersionsMap = Map<String, VersionMap>
 
+
+fun Patch<*>.versionCodesFor(
+    packageName: String?,
+    versionName: String,
+): Map<SupportedAbi, Int>? {
+    val compat = compatibility ?: return null
+    return compat
+        .filter { packageName == null || it.packageName == null || it.packageName == packageName }
+        .flatMap { it.targets }
+        .find { it.version == versionName && !it.versionCodes.isNullOrEmpty() }
+        ?.versionCodes
+}
+
+fun Iterable<Patch<*>>.versionCodesFor(
+    packageName: String?,
+    versionName: String,
+): Map<SupportedAbi, Int>? =
+    firstNotNullOfOrNull { it.versionCodesFor(packageName, versionName) }
 
 @Suppress("DEPRECATION")
 fun Patch<*>.versionsFor(


### PR DESCRIPTION
Displays target version codes in CLI command outputs:

- `list-versions`: Appends formatted version codes (e.g. `[versionCodes: ARM64_V8A=384109456]`) to compatible version strings.
- `list-patches`: Adds a `Version codes:` section under compatible packages listing the target version codes per ABI.