### PR TITLE
refactor: Clean up and modernize Kotlin syntax in CLI and engine

### DIFF
--- a/src/main/kotlin/app/morphe/desktop/command/CommandUtils.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/CommandUtils.kt
@@ -11,8 +11,8 @@ import java.io.File
 
 internal fun checkFileExistsOrIsUrl(files: Set<File>, spec: CommandSpec) : Set<File> {
     files.firstOrNull {
-        !it.exists() && !it.toString().let {
-            it.startsWith("http:/") || it.startsWith("https:/")
+        !it.exists() && !it.toString().let { url ->
+            url.startsWith("http:/") || url.startsWith("https:/")
         }
     }?.let {
         throw CommandLine.ParameterException(spec.commandLine(), "${it.name} can not be found")

--- a/src/main/kotlin/app/morphe/desktop/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/PatchCommand.kt
@@ -529,12 +529,11 @@ internal object PatchCommand : Callable<Int> {
                     }
                 } else {
                     logger.info("Options file ${file.path} does not exist, generating with defaults")
-                    val freshBundles = patchSnapshots
                     val json = Json { prettyPrint = true }
                     file.absoluteFile.parentFile?.mkdirs()
-                    file.writeText(json.encodeToString(freshBundles))
+                    file.writeText(json.encodeToString(patchSnapshots))
                     logger.info("Generated options file at ${file.path}")
-                    loadedBundles.zip(freshBundles).associate { (lb, b) ->
+                    loadedBundles.zip(patchSnapshots).associate { (lb, b) ->
                         lb.sourceFile to b
                     }
                 }
@@ -782,41 +781,38 @@ internal object PatchCommand : Callable<Int> {
                 // stacktrace on failure since there's no "View details" UI
                 // in a terminal.
                 logger.info("Applying ${finalPatches.size} patches...")
-                patchingResult.addStepResult(
-                    PatchingStep.PATCHING,
-                    {
-                        runBlocking {
-                            patcher().collect { patchResult ->
-                                val patchName = patchResult.patch.name ?: "Unknown"
-                                patchResult.exception?.let { exception ->
-                                    StringWriter().use { writer ->
-                                        exception.printStackTrace(PrintWriter(writer))
+                patchingResult.addStepResult(PatchingStep.PATCHING) {
+                    runBlocking {
+                        patcher().collect { patchResult ->
+                            val patchName = patchResult.patch.name ?: "Unknown"
+                            patchResult.exception?.let { exception ->
+                                StringWriter().use { writer ->
+                                    exception.printStackTrace(PrintWriter(writer))
 
-                                        logger.severe("FAILED: $patchName\n$writer")
+                                    logger.severe("FAILED: $patchName\n$writer")
 
-                                        patchingResult.failedPatches.add(
-                                            FailedPatch(
-                                                patchResult.patch.toSerializablePatch(),
-                                                writer.toString()
-                                            )
+                                    patchingResult.failedPatches.add(
+                                        FailedPatch(
+                                            patchResult.patch.toSerializablePatch(),
+                                            writer.toString()
                                         )
+                                    )
 
-                                        if (!continueOnError) {
-                                            patchingResult.success = false
-                                            throw PatchFailedException(
-                                                "FAILED: $patchName",
-                                                exception
-                                            )
-                                        }
+                                    if (!continueOnError) {
+                                        patchingResult.success = false
+                                        throw PatchFailedException(
+                                            "FAILED: $patchName",
+                                            exception
+                                        )
                                     }
-                                } ?: run {
-                                    patchingResult.appliedPatches.add(patchResult.patch.toSerializablePatch())
-                                    logger.info("Applied: $patchName")
                                 }
+                            } ?: run {
+                                patchingResult.appliedPatches.add(patchResult.patch.toSerializablePatch())
+                                logger.info("Applied: $patchName")
                             }
                         }
                     }
-                )
+                }
 
                 // patches lives in the outer try scope (needed for patchesSnapshot and options
                 // file generation before the Patcher block). Clear it explicitly now — after
@@ -830,32 +826,26 @@ internal object PatchCommand : Callable<Int> {
             // region Save.
 
             inputApk.copyTo(patcherTemporaryFilesPath.resolve(inputApk.name), overwrite = true).apply {
-                patchingResult.addStepResult(
-                    PatchingStep.REBUILDING,
-                    {
-                        patcherResult.applyTo(this)
-                    }
-                )
+                patchingResult.addStepResult(PatchingStep.REBUILDING) {
+                    patcherResult.applyTo(this)
+                }
             }.let { patchedApkFile ->
                 if (!mount && !unsigned) {
-                    patchingResult.addStepResult(
-                        PatchingStep.SIGNING,
-                        {
-                            signWithLegacyFallback(
-                                primary = ApkUtils.KeyStoreDetails(
-                                    keystoreFilePath,
-                                    keyStorePassword,
-                                    keyStoreEntryAlias,
-                                    keyStoreEntryPassword,
-                                ),
-                                allowLegacyFallback = keyStoreEntryAlias == DEFAULT_KEYSTORE_ALIAS &&
-                                    keyStoreEntryPassword == DEFAULT_KEYSTORE_PASSWORD,
-                                logger = logger,
-                            ) { details ->
-                                ApkUtils.signApk(patchedApkFile, outputFilePath, signer, details)
-                            }
+                    patchingResult.addStepResult(PatchingStep.SIGNING) {
+                        signWithLegacyFallback(
+                            primary = ApkUtils.KeyStoreDetails(
+                                keystoreFilePath,
+                                keyStorePassword,
+                                keyStoreEntryAlias,
+                                keyStoreEntryPassword,
+                            ),
+                            allowLegacyFallback = keyStoreEntryAlias == DEFAULT_KEYSTORE_ALIAS &&
+                                keyStoreEntryPassword == DEFAULT_KEYSTORE_PASSWORD,
+                            logger = logger,
+                        ) { details ->
+                            ApkUtils.signApk(patchedApkFile, outputFilePath, signer, details)
                         }
-                    )
+                    }
                 } else {
                     patchedApkFile.copyTo(outputFilePath, overwrite = true)
                 }
@@ -869,25 +859,21 @@ internal object PatchCommand : Callable<Int> {
             // region Install.
 
             deviceSerial?.let {
-                patchingResult.addStepResult(
-                    PatchingStep.INSTALLING,
-                    {
-                        runBlocking {
-                            val result = installer!!.install(Installer.Apk(outputFilePath, packageName))
-                            when (result) {
-                                RootInstallerResult.FAILURE -> {
-                                    logger.severe("Failed to mount the patched APK file")
-                                    throw IllegalStateException("Failed to mount the patched APK file")
-                                }
-                                is AdbInstallerResult.Failure -> {
-                                    logger.severe(result.exception.toString())
-                                    throw result.exception
-                                }
-                                else -> logger.info("Installed the patched APK file")
+                patchingResult.addStepResult(PatchingStep.INSTALLING) {
+                    runBlocking {
+                        when (val result = installer!!.install(Installer.Apk(outputFilePath, packageName))) {
+                            RootInstallerResult.FAILURE -> {
+                                logger.severe("Failed to mount the patched APK file")
+                                throw IllegalStateException("Failed to mount the patched APK file")
                             }
+                            is AdbInstallerResult.Failure -> {
+                                logger.severe(result.exception.toString())
+                                throw result.exception
+                            }
+                            else -> logger.info("Installed the patched APK file")
                         }
                     }
-                )
+                }
             }
 
             // endregion

--- a/src/main/kotlin/app/morphe/desktop/command/PatchFileResolver.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/PatchFileResolver.kt
@@ -42,7 +42,7 @@ object PatchFileResolver {
                 // morphe.software/add-source links, bare owner/repo.
 
                 val parsed = RemotePatchSourceFactory.parse(url)
-                    ?: throw IllegalArgumentException("Unrecognized patch URL: \$url")
+                    ?: throw IllegalArgumentException("Unrecognized patch URL: $url")
 
                 val source = parsed.instantiate(httpClient)
 

--- a/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
+++ b/src/main/kotlin/app/morphe/engine/BootstrapDownloader.kt
@@ -79,39 +79,39 @@ object BootstrapDownloader {
         if (toDownload > 0) listener?.onStart(toDownload)
 
         var index = 0
-        for (plan in plans) {
-            if (!plan.needsDownload) {
-                downloadedFiles.add(plan.target)
+        for ((dep, target, needsDownload) in plans) {
+            if (!needsDownload) {
+                downloadedFiles.add(target)
                 continue
             }
-            if (plan.target.exists()) {
-                logger.warning("Cache invalid for ${plan.dep.fileName}, redownloading.")
-                plan.target.delete()
+            if (target.exists()) {
+                logger.warning("Cache invalid for ${dep.fileName}, redownloading.")
+                target.delete()
             }
 
-            logger.info("Downloading ${plan.dep.fileName}...")
+            logger.info("Downloading ${dep.fileName}...")
             val current = index
             try {
-                downloadWithProgress(plan.dep, plan.target) { done, total ->
-                    listener?.onProgress(current, toDownload, plan.dep.fileName, done, total)
+                downloadWithProgress(dep, target) { done, total ->
+                    listener?.onProgress(current, toDownload, dep.fileName, done, total)
                 }
             } catch (e: Exception) {
-                plan.target.delete()
-                val message = "Failed to download ${plan.dep.fileName}: ${e.message}"
+                target.delete()
+                val message = "Failed to download ${dep.fileName}: ${e.message}"
                 logger.severe(message)
                 listener?.onError(message)
                 throw BootstrapException(message, e)
             }
 
-            if (!verifyHash(plan.target, plan.dep.expectedHash)) {
-                plan.target.delete()
-                val message = "Checksum mismatch for ${plan.dep.fileName}."
+            if (!verifyHash(target, dep.expectedHash)) {
+                target.delete()
+                val message = "Checksum mismatch for ${dep.fileName}."
                 logger.severe(message)
                 listener?.onError(message)
                 throw BootstrapException(message)
             }
 
-            downloadedFiles.add(plan.target)
+            downloadedFiles.add(target)
             index++
         }
 

--- a/src/main/kotlin/app/morphe/engine/MorpheComponents.kt
+++ b/src/main/kotlin/app/morphe/engine/MorpheComponents.kt
@@ -37,6 +37,6 @@ object MorpheComponents {
                 .getResourceAsStream(resourcePath)
                 ?.use { Properties().apply { load(it) }.getProperty(key) }
                 ?.trim()
-                ?.takeUnless { it.isEmpty() || it.startsWith("\${") }
+                ?.takeUnless { it.isEmpty() || it.startsWith($$"${") }
         }.getOrNull()
 }

--- a/src/main/kotlin/app/morphe/engine/PatchEngine.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchEngine.kt
@@ -275,7 +275,7 @@ object PatchEngine {
                 // `failedPatches` for the UI to display. Only strict mode (failOnError=true)
                 // treats any failure as an overall failure.
                 return Result(
-                    success = if (config.failOnError) failedPatches.isEmpty() else true,
+                    success = !config.failOnError || failedPatches.isEmpty(),
                     outputPath = config.outputApk.absolutePath,
                     packageName = packageName,
                     packageVersion = packageVersion,

--- a/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchExtensions.kt
@@ -118,8 +118,8 @@ fun Iterable<Patch<*>>.mostCommonCompatibleVersions(
         for (patch in this@mostCommonCompatibleVersions) {
             val compat = patch.compatibility
             if (!compat.isNullOrEmpty()) {
-                for (entry in compat) {
-                    entry.packageName?.let { add(it) }
+                for ((packageName) in compat) {
+                    packageName?.let { add(it) }
                 }
             } else {
                 @Suppress("DEPRECATION")

--- a/src/main/kotlin/app/morphe/engine/network/HttpService.kt
+++ b/src/main/kotlin/app/morphe/engine/network/HttpService.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlin.time.Duration.Companion.milliseconds
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
@@ -193,17 +194,17 @@ class HttpService(
                 }
                 val wait = (t.retryAfterMillis ?: delayMs).coerceAtMost(MAX_RETRY_DELAY_MS)
                 logger.warning("$operation hit 429 (attempt $attempt/$MAX_RETRY_ATTEMPTS), waiting ${wait}ms")
-                delay(wait)
+                delay(wait.milliseconds)
                 delayMs = (delayMs * 2).coerceAtMost(MAX_RETRY_DELAY_MS)
             } catch (t: HttpException) {
                 if (!t.isRetryable || attempt >= MAX_RETRY_ATTEMPTS) throw t
                 logger.warning("$operation attempt $attempt: retryable HTTP error: ${t.message}")
-                delay(delayMs)
+                delay(delayMs.milliseconds)
                 delayMs = (delayMs * 2).coerceAtMost(MAX_RETRY_DELAY_MS)
             } catch (t: Exception) {
                 if (attempt >= MAX_RETRY_ATTEMPTS) throw t
                 logger.warning("$operation attempt $attempt failed: ${t::class.simpleName}: ${t.message}")
-                delay(delayMs)
+                delay(delayMs.milliseconds)
                 delayMs = (delayMs * 2).coerceAtMost(MAX_RETRY_DELAY_MS)
             }
         }

--- a/src/main/kotlin/app/morphe/engine/util/PortablePaths.kt
+++ b/src/main/kotlin/app/morphe/engine/util/PortablePaths.kt
@@ -48,7 +48,7 @@ object PortablePaths {
             // target == anchor — fall back to absolute in that edge case to
             // avoid storing an empty string that would round-trip to anchor.
             val rel = target.relativeTo(anchor).path
-            if (rel.isEmpty()) absolutePath else rel
+            rel.ifEmpty { absolutePath }
         } else {
             absolutePath
         }

--- a/src/main/kotlin/app/morphe/engine/util/SignatureIdentity.kt
+++ b/src/main/kotlin/app/morphe/engine/util/SignatureIdentity.kt
@@ -9,7 +9,6 @@ import java.io.File
 import java.security.KeyStore
 import java.security.Security
 import java.security.cert.Certificate
-import java.util.Arrays
 
 /**
  * Identifies a signing certificate by the same value Android reports in
@@ -19,7 +18,7 @@ import java.util.Arrays
  * signatures=PackageSignatures{… signatures:[a7001add], past signatures:[]}
  * ```
  *
- * That `a7001add` is `Integer.toHexString(Arrays.hashCode(certDER))` of the
+ * That `a7001add` is `Integer.toHexString(certDER.contentHashCode())` of the
  * signing cert (Android's `Signature.hashCode()`). Computing the same value from
  * Morphe's keystore cert lets us tell, from a connected device, whether an
  * installed app was signed by Morphe — without pulling the APK.
@@ -30,9 +29,9 @@ import java.util.Arrays
  */
 object SignatureIdentity {
 
-    /** Android's signature id for [cert]: `toHexString(Arrays.hashCode(DER))`. */
+    /** Android's signature id for [cert]: `toHexString(DER.contentHashCode())`. */
     fun idForCert(cert: Certificate): String =
-        Integer.toHexString(Arrays.hashCode(cert.encoded))
+        Integer.toHexString(cert.encoded.contentHashCode())
 
     /**
      * Signature id of the cert under [alias] in the BKS [keystoreFile], or null


### PR DESCRIPTION
Cleans up compiler inspection warnings and modernizes syntax across the CLI and engine modules:

- Fixes shadowed lambda parameters and escaped string interpolation in CLI commands.
- Moves trailing lambdas out of parentheses and simplifies `when` declarations in `PatchCommand`.
- Converts `HttpService` delay calls to Kotlin `Duration`.
- Adopts destructuring declarations in `BootstrapDownloader` and `PatchExtensions` loops.
- Replaces legacy Java calls with Kotlin stdlib equivalents (`contentHashCode()`, `ifEmpty`, simplified boolean logic).