### PR TITLE
fix: Recognize repository URLs passed to `--patches` on Windows

### DIFF
--- a/src/main/kotlin/app/morphe/desktop/command/CommandUtils.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/CommandUtils.kt
@@ -11,7 +11,7 @@ import java.io.File
 
 internal fun checkFileExistsOrIsUrl(files: Set<File>, spec: CommandSpec) : Set<File> {
     files.firstOrNull {
-        !it.exists() && !it.toString().let { url ->
+        !it.exists() && !it.invariantSeparatorsPath.let { url ->
             url.startsWith("http:/") || url.startsWith("https:/")
         }
     }?.let {

--- a/src/main/kotlin/app/morphe/desktop/command/PatchFileResolver.kt
+++ b/src/main/kotlin/app/morphe/desktop/command/PatchFileResolver.kt
@@ -31,10 +31,11 @@ object PatchFileResolver {
         httpClient: HttpClient
     ): Set<File> {
         val urlEntry = patchFiles.firstOrNull {
-            it.path.startsWith("http:/") || it.path.startsWith("https:/")
+            it.invariantSeparatorsPath.startsWith("http:/") ||
+                it.invariantSeparatorsPath.startsWith("https:/")
         } ?: return patchFiles
 
-        val url = urlEntry.path
+        val url = urlEntry.invariantSeparatorsPath
 
         return runBlocking {
             try {


### PR DESCRIPTION
#### How to reproduce

On windows, run this in either PowerShell or Command Prompt:

```shell
java -jar morphe-desktop-1.14.0-all.jar list-patches --patches=https://github.com/MorpheApp/morphe-patches
```

Returns:
```
morphe-patches can not be found
```

#### Bug:

--patches stores the URL as a File, which changes / to \ on Windows. The existing checks only recognize URLs containing /, so Morphe treats the repository as a missing local file.

#### Proposed fix:

Use `invariantSeparatorsPath` when checking and resolving patch sources so GitHub and GitLab repository URLs reach the existing resolver.
Local `.mpp` paths continue using the original `File` objects.

#### Introduced in

Repository URL support was added in [#71](https://github.com/MorpheApp/morphe-desktop/pull/71) and first released in `v1.8.0-dev.8`. The Windows path-handling issue has been present since that initial implementation.