### PR TITLE
fix: Prevent NPE crash in `IoUsageSampler` on Windows

### DIFF
--- a/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
@@ -401,14 +401,14 @@ data class IoUsage(val readKbPerSec: Int, val writeKbPerSec: Int, val totalKbPer
  */
 class IoUsageSampler {
     private val os = SystemInfo().operatingSystem
-    private val currentProcess = os.getProcess(os.processId)
+    private val currentProcess = os.currentProcess
 
     private var previousRead = -1L
     private var previousWrite = -1L
     private var previousUptimeMs = 0L
 
     fun sample(): IoUsage? {
-        currentProcess.updateAttributes()
+        if (currentProcess == null || !currentProcess.updateAttributes()) return null
         val read = currentProcess.bytesRead
         val write = currentProcess.bytesWritten
 


### PR DESCRIPTION
Closes #275.

---

- `os.getProcess(pid)` can return `null` on Windows, causing a crash mid-patching
- Switched to `os.currentProcess`, OSHI's proper API for the current JVM process
- Added a null guard so I/O stats just go blank instead of crashing if it still fails

Tested on Windows 10 VM, should also work on Windows 11 as well.