### PR TITLE
chore: Remove redundant null check in `IoUsageSampler`

### DIFF
--- a/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
@@ -408,7 +408,7 @@ class IoUsageSampler {
     private var previousUptimeMs = 0L
 
     fun sample(): IoUsage? {
-        if (currentProcess == null || !currentProcess.updateAttributes()) return null
+        if (!currentProcess.updateAttributes()) return null
         val read = currentProcess.bytesRead
         val write = currentProcess.bytesWritten
 


### PR DESCRIPTION
Removes a redundant `currentProcess == null` check in `IoUsageSampler.sample()`.

Following the recent bump to `oshi-core` 7.x, `operatingSystem.currentProcess` is guaranteed to be non-null, which caused Kotlin to emit a compiler warning (`Condition is always 'false'`). The check now only validates `!currentProcess.updateAttributes()`.