### PR TITLE
refactor: Unify GUI logs across patcher and Koin

### DIFF
--- a/src/main/kotlin/app/morphe/gui/App.kt
+++ b/src/main/kotlin/app/morphe/gui/App.kt
@@ -43,6 +43,9 @@ import cafe.adriel.voyager.transitions.ScreenTransition
 import kotlinx.coroutines.launch
 import org.koin.compose.KoinApplication
 import org.koin.compose.koinInject
+import org.koin.core.logger.Level as KoinLevel
+import org.koin.core.logger.Logger as KoinLogger
+import org.koin.core.logger.MESSAGE
 import org.koin.dsl.koinConfiguration
 
 /**
@@ -103,9 +106,23 @@ fun app(
     }
 
     KoinApplication(koinConfiguration {
+        logger(KoinLoggerAdapter)
         modules(appModule)
     }) {
         appContent(initialSimplifiedMode = initialSimplifiedMode)
+    }
+}
+
+private object KoinLoggerAdapter : KoinLogger(KoinLevel.INFO) {
+    override fun display(level: KoinLevel, msg: MESSAGE) {
+        val taggedMessage = "[Koin] $msg"
+        when (level) {
+            KoinLevel.ERROR -> Logger.error(taggedMessage)
+            KoinLevel.WARNING -> Logger.warn(taggedMessage)
+            KoinLevel.INFO -> Logger.info(taggedMessage)
+            KoinLevel.DEBUG -> Logger.debug(taggedMessage)
+            KoinLevel.NONE -> Unit
+        }
     }
 }
 

--- a/src/main/kotlin/app/morphe/gui/GuiMain.kt
+++ b/src/main/kotlin/app/morphe/gui/GuiMain.kt
@@ -20,6 +20,7 @@ import app.morphe.gui.data.model.AppConfig
 import app.morphe.gui.ui.components.LocalFrameWindowScope
 import app.morphe.gui.util.DeviceMonitor
 import app.morphe.gui.util.FileUtils
+import app.morphe.gui.util.Logger
 import io.github.vinceglb.filekit.FileKit
 import java.awt.Dimension
 import java.awt.Taskbar
@@ -34,6 +35,8 @@ import org.jetbrains.skia.Image
  * The app switches between simplified and full mode dynamically via settings.
  */
 fun launchGui(args: Array<String>) {
+    Logger.init()
+
     // FileKit backs the native OS file/folder pickers (JNA on Windows/macOS,
     // XDG Desktop Portal on Linux). Must run once before any picker is used;
     // appId doubles as the DBus application id on Linux.

--- a/src/main/kotlin/app/morphe/gui/util/Logger.kt
+++ b/src/main/kotlin/app/morphe/gui/util/Logger.kt
@@ -10,8 +10,13 @@ import app.morphe.gui.data.constants.AppConstants
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.text.MessageFormat
 import java.text.SimpleDateFormat
 import java.util.*
+import java.util.logging.Handler
+import java.util.logging.Level as JVLevel
+import java.util.logging.LogRecord
+import java.util.logging.Logger as JVLogger
 
 /**
  * Simple file logger with rotation support.
@@ -42,6 +47,9 @@ object Logger {
         if (initialized) return
 
         try {
+            // Install JUL bridge early so logs during startup (e.g. MorpheData) are unified
+            installJulBridge()
+
             val logsDir = FileUtils.getLogsDir()
             logFile = File(logsDir, LOG_FILE_NAME)
 
@@ -69,6 +77,63 @@ object Logger {
         } catch (e: Exception) {
             System.err.println("Failed to initialize logger: ${e.message}")
         }
+    }
+
+    /**
+     * Bridges java.util.logging for `app.morphe` into this Logger.
+     * Sets useParentHandlers = false on "app.morphe" to isolate it from the root ConsoleHandler.
+     */
+    private fun installJulBridge() {
+        val morpheLogger = JVLogger.getLogger("app.morphe")
+        morpheLogger.useParentHandlers = false
+
+        for (handler in morpheLogger.handlers.toList()) {
+            if (handler is JulBridgeHandler) {
+                morpheLogger.removeHandler(handler)
+            }
+        }
+
+        morpheLogger.addHandler(JulBridgeHandler())
+    }
+
+    private class JulBridgeHandler : Handler() {
+        override fun publish(record: LogRecord) {
+            val rawMessage = record.message ?: return
+            if (rawMessage.isBlank()) return
+
+            val message = runCatching {
+                val params = record.parameters
+                if (params != null && params.isNotEmpty()) {
+                    MessageFormat.format(rawMessage, *params)
+                } else rawMessage
+            }.getOrDefault(rawMessage)
+
+            val loggerName = record.loggerName ?: ""
+            val isPatcher = loggerName.startsWith("app.morphe.patcher")
+            val taggedMessage = if (isPatcher) "[PATCH] $message" else message
+
+            when {
+                record.level.intValue() >= JVLevel.SEVERE.intValue() -> {
+                    if (record.thrown != null) {
+                        error(taggedMessage, record.thrown)
+                    } else {
+                        error(taggedMessage)
+                    }
+                }
+                record.level.intValue() >= JVLevel.WARNING.intValue() -> {
+                    warn(taggedMessage)
+                }
+                record.level.intValue() >= JVLevel.INFO.intValue() -> {
+                    info(taggedMessage)
+                }
+                else -> {
+                    debug(taggedMessage)
+                }
+            }
+        }
+
+        override fun flush() {}
+        override fun close() {}
     }
 
     /**


### PR DESCRIPTION
- Unifies GUI log formatting across `morphe-patcher` and Koin, ensuring all console and file logs share consistent timestamps and levels instead of raw multi-line output.
- Routes `app.morphe` JUL logs to GUI `Logger`, isolating them from the root console handler and tagging patcher messages with `[PATCH]`.
- Adapts Koin logger output to include standard timestamps.
- Initializes `Logger` early on GUI launch.