### PR TITLE
fix: Resolve `IoUsageSampler` NPE regression

### DIFF
--- a/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
@@ -401,16 +401,16 @@ data class IoUsage(val readKbPerSec: Int, val writeKbPerSec: Int, val totalKbPer
  */
 class IoUsageSampler {
     private val os = SystemInfo().operatingSystem
-    private val currentProcess = os.currentProcess
+    private val pid = os.processId
 
     private var previousRead = -1L
     private var previousWrite = -1L
     private var previousUptimeMs = 0L
 
     fun sample(): IoUsage? {
-        if (!currentProcess.updateAttributes()) return null
-        val read = currentProcess.bytesRead
-        val write = currentProcess.bytesWritten
+        val process = os.getProcess(pid) ?: return null
+        val read = process.bytesRead
+        val write = process.bytesWritten
 
         val uptimeMs = System.currentTimeMillis()
         val elapsed = uptimeMs - previousUptimeMs


### PR DESCRIPTION
Fixes regression I made in #291, basically it's the same fix as #284 but now Kotlin warning in IDE doesn't show up.