### PR TITLE
fix: Harden `IoUsageSampler` against corrupted Windows performance counters

### DIFF
--- a/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import oshi.SystemInfo
+import oshi.software.os.OSProcess
 
 class PatchingViewModel(
     private val config: PatchConfig,
@@ -401,16 +402,29 @@ data class IoUsage(val readKbPerSec: Int, val writeKbPerSec: Int, val totalKbPer
  */
 class IoUsageSampler {
     private val os = SystemInfo().operatingSystem
-    private val pid = os.processId
+    private val currentProcess: OSProcess? = try {
+        os.currentProcess
+    } catch (e: Exception) {
+        null
+    }
 
     private var previousRead = -1L
     private var previousWrite = -1L
     private var previousUptimeMs = 0L
 
     fun sample(): IoUsage? {
-        val process = os.getProcess(pid) ?: return null
-        val read = process.bytesRead
-        val write = process.bytesWritten
+        val p = currentProcess ?: return null
+
+        val updated = try {
+            p.updateAttributes()
+        } catch (e: Exception) {
+            false
+        }
+
+        if (!updated) return null
+
+        val read = p.bytesRead
+        val write = p.bytesWritten
 
         val uptimeMs = System.currentTimeMillis()
         val elapsed = uptimeMs - previousUptimeMs


### PR DESCRIPTION
Sorry for the previous half-fixes - I don't run Windows daily, so I couldn't reproduce this locally. This time I verified the fix directly against the OSHI 7.6.1 source code.

On some Windows machines the `IDPROCESS` performance counter can be missing or corrupted, causing OSHI to throw an uncaught `IllegalStateException` that crashed the patcher. Both the process handle acquisition and each `updateAttributes()` call are now wrapped in try-catch, so sampling degrades gracefully instead.